### PR TITLE
fix: remove dependency

### DIFF
--- a/src/DNSStack.ts
+++ b/src/DNSStack.ts
@@ -1,4 +1,4 @@
-import { aws_route53 as Route53, Stack, StackProps, aws_ssm as SSM } from 'aws-cdk-lib';
+import { aws_route53 as Route53, Stack, StackProps, aws_ssm as SSM, CfnOutput } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { Statics } from './statics';
 
@@ -23,8 +23,18 @@ export class DNSStack extends Stack {
       zoneName: rootZoneName,
     });
 
-    //TODO Maandag: Hier een tijdelijke cfnOutput maken zodat certstack fatsoenlijk verwijderd kan worden.
-    
+    // Tijdelijke output zodat certificatestack verwijderd kan worden
+    if(props.branch == 'acceptance') {
+      const compat_output = new CfnOutput(this, 'temp-output', {
+        value: 'Z03105592Z01S4FRBQZQV',
+        exportName: 'mijn-api-dns-stack:ExportsOutputRefmijncspB83B491BB53D10A4',
+      });
+      compat_output.overrideLogicalId('ExportsOutputRefmijncspB83B491BB53D10A4');
+    } 
+    if(props.branch == 'production') {
+      
+    }
+
     this.zone = new Route53.HostedZone(this, 'mijn-csp', {
       zoneName: `mijn.${this.cspRootZone.zoneName}`,
     });

--- a/src/DNSStack.ts
+++ b/src/DNSStack.ts
@@ -24,15 +24,15 @@ export class DNSStack extends Stack {
     });
 
     // Tijdelijke output zodat certificatestack verwijderd kan worden
-    if(props.branch == 'acceptance') {
+    if (props.branch == 'acceptance') {
       const compat_output = new CfnOutput(this, 'temp-output', {
         value: 'Z03105592Z01S4FRBQZQV',
         exportName: 'mijn-api-dns-stack:ExportsOutputRefmijncspB83B491BB53D10A4',
       });
       compat_output.overrideLogicalId('ExportsOutputRefmijncspB83B491BB53D10A4');
-    } 
-    if(props.branch == 'production') {
-      
+    }
+    if (props.branch == 'production') {
+
     }
 
     this.zone = new Route53.HostedZone(this, 'mijn-csp', {

--- a/src/DNSStack.ts
+++ b/src/DNSStack.ts
@@ -23,6 +23,8 @@ export class DNSStack extends Stack {
       zoneName: rootZoneName,
     });
 
+    //TODO Maandag: Hier een tijdelijke cfnOutput maken zodat certstack fatsoenlijk verwijderd kan worden.
+    
     this.zone = new Route53.HostedZone(this, 'mijn-csp', {
       zoneName: `mijn.${this.cspRootZone.zoneName}`,
     });


### PR DESCRIPTION
Fixes #28 
Voegt een tijdelijke output toe zodat certificatestack verwijderd kan worden.