### PR TITLE
feat: Add initial e2e tests

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,27 @@
+name: Playwright Tests
+on:
+  push:
+    branches: [ production, acceptance ]
+  pull_request:
+    branches: [ production, acceptance ]
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '14.x'
+    - name: Install dependencies
+      run: yarn
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps
+    - name: Run Playwright tests
+      run: yarn playwright test
+    - uses: actions/upload-artifact@v2
+      if: always()
+      with:
+        name: playwright-report
+        path: test/playwright/report/
+        retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ src/app/**/shared
 src/app/**/tests/output
 .DS_Store
 test/playwright/report
-test/playwright/screenshots
 !/.projenrc.js
 /test-reports/
 junit.xml

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ jspm_packages/
 src/app/**/shared
 src/app/**/tests/output
 .DS_Store
+test/playwright/report
+test/playwright/screenshots
 !/.projenrc.js
 /test-reports/
 junit.xml

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -1,6 +1,10 @@
 {
   "dependencies": [
     {
+      "name": "@playwright/test",
+      "type": "build"
+    },
+    {
       "name": "@types/jest",
       "type": "build"
     },

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -51,7 +51,6 @@ const project = new awscdk.AwsCdkTypeScriptApp({
     'src/app/**/tests/output',
     '.DS_Store',
     'test/playwright/report',
-    'test/playwright/screenshots'
   ],
 });
 

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -16,6 +16,7 @@ const project = new awscdk.AwsCdkTypeScriptApp({
   // description: undefined,  /* The description is just a string that helps people understand the purpose of the package. */
   devDeps: [
     'copyfiles',
+    '@playwright/test',
   ], /* Build dependencies for this module. */
   depsUpgradeOptions: {
     workflowOptions: {
@@ -28,7 +29,7 @@ const project = new awscdk.AwsCdkTypeScriptApp({
   jestOptions: {
     jestConfig: {
       setupFiles: ['dotenv/config'],
-      testPathIgnorePatterns: ['/node_modules/', '/cdk.out'],
+      testPathIgnorePatterns: ['/node_modules/', '/cdk.out', '/test/playwright'],
       roots: ['src', 'test'],
     },
   },
@@ -49,6 +50,8 @@ const project = new awscdk.AwsCdkTypeScriptApp({
     'src/app/**/shared',
     'src/app/**/tests/output',
     '.DS_Store',
+    'test/playwright/report',
+    'test/playwright/screenshots'
   ],
 });
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "projen": "npx projen"
   },
   "devDependencies": {
+    "@playwright/test": "^1.22.2",
     "@types/jest": "^27.5.1",
     "@types/node": "^14",
     "@typescript-eslint/eslint-plugin": "^5",
@@ -72,7 +73,8 @@
     ],
     "testPathIgnorePatterns": [
       "/node_modules/",
-      "/cdk.out"
+      "/cdk.out",
+      "/test/playwright"
     ],
     "roots": [
       "src",
@@ -94,7 +96,8 @@
     "coverageDirectory": "coverage",
     "coveragePathIgnorePatterns": [
       "/node_modules/",
-      "/cdk.out"
+      "/cdk.out",
+      "/test/playwright"
     ],
     "watchPathIgnorePatterns": [
       "/node_modules/"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,107 @@
+import type { PlaywrightTestConfig } from '@playwright/test';
+import { devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+const config: PlaywrightTestConfig = {
+  testDir: './test/playwright',
+  /* Maximum time one test can run for. */
+  timeout: 30 * 1000,
+  expect: {
+    /**
+     * Maximum time expect() should wait for the condition to be met.
+     * For example in `await expect(locator).toHaveText();`
+     */
+    timeout: 5000
+  },
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: [ [ 'html', { outputFolder: 'test/playwright/report' }] ],
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
+    actionTimeout: 0,
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    // baseURL: 'http://localhost:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+      },
+    },
+
+    {
+      name: 'firefox',
+      use: {
+        ...devices['Desktop Firefox'],
+      },
+    },
+
+    {
+      name: 'webkit',
+      use: {
+        ...devices['Desktop Safari'],
+      },
+    },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: {
+    //     ...devices['Pixel 5'],
+    //   },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: {
+    //     ...devices['iPhone 12'],
+    //   },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: {
+    //     channel: 'msedge',
+    //   },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: {
+    //     channel: 'chrome',
+    //   },
+    // },
+  ],
+
+  /* Folder for test artifacts such as screenshots, videos, traces, etc. */
+  // outputDir: 'test-results/',
+
+  /* Run your local dev server before starting the tests */
+  // webServer: {
+  //   command: 'npm run start',
+  //   port: 3000,
+  // },
+};
+
+export default config;

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -111,7 +111,7 @@ Object {
     },
     \\"build\\": {
       \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-test-mijn-api/testmijnapicloudfrontstackB17003A6.assets.json\\\\\\" --verbose publish \\\\\\"cc36fde147881b26584660dff21bc38d1b5f76c5613fc21141b5cfc0bbeed3a9:test-eu-west-1\\\\\\"\\"
+        \\"cdk-assets --path \\\\\\"assembly-test-mijn-api/testmijnapicloudfrontstackB17003A6.assets.json\\\\\\" --verbose publish \\\\\\"d3c76135a48385b5665e92802a4149612e43330005c4d9eb92054bb6c812d1de:test-eu-west-1\\\\\\"\\"
       ]
     }
   }
@@ -350,7 +350,7 @@ Object {
     },
     \\"build\\": {
       \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-test-mijn-api/testmijnapiapistackB91CFA18.assets.json\\\\\\" --verbose publish \\\\\\"aeee8a4b4cf311f8babf9e3792b76d56f1fc8ea182f2738e9f39ca7699b165de:test-eu-west-1\\\\\\"\\"
+        \\"cdk-assets --path \\\\\\"assembly-test-mijn-api/testmijnapiapistackB91CFA18.assets.json\\\\\\" --verbose publish \\\\\\"71ffaaf6a2857ba578bc3e23859bd00e27b5faef69cb279befd1e38ecf24d9d3:test-eu-west-1\\\\\\"\\"
       ]
     }
   }
@@ -409,7 +409,7 @@ Object {
     },
     \\"build\\": {
       \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-test-mijn-api/testmijnapiapistackB91CFA18.assets.json\\\\\\" --verbose publish \\\\\\"80db344122800ea26250aaa8703d9810aba1c62fa66e2f1413e6a86aa1c78c8e:test-eu-west-1\\\\\\"\\"
+        \\"cdk-assets --path \\\\\\"assembly-test-mijn-api/testmijnapiapistackB91CFA18.assets.json\\\\\\" --verbose publish \\\\\\"50f268c54c53e38bc500777540494c1120c215335fc38803974d9cd7250402c3:test-eu-west-1\\\\\\"\\"
       ]
     }
   }
@@ -468,7 +468,7 @@ Object {
     },
     \\"build\\": {
       \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-test-mijn-api/testmijnapiapistackB91CFA18.assets.json\\\\\\" --verbose publish \\\\\\"39d9bbdf80d31affd29ac7f9a5fc11c70c05a1b936489416e7cc1990e33eb8dc:test-eu-west-1\\\\\\"\\"
+        \\"cdk-assets --path \\\\\\"assembly-test-mijn-api/testmijnapiapistackB91CFA18.assets.json\\\\\\" --verbose publish \\\\\\"5358f1cac8f26c76fe68e6c3efb6b1de800b64ca366861b9b9c11c7dfc14e0f0:test-eu-west-1\\\\\\"\\"
       ]
     }
   }
@@ -586,7 +586,7 @@ Object {
     },
     \\"build\\": {
       \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-test-mijn-api/testmijnapiapistackB91CFA18.assets.json\\\\\\" --verbose publish \\\\\\"a4645cc2b2d692bdbeedb6a481b827aff887c10a893282a82457391f84e97785:test-eu-west-1\\\\\\"\\"
+        \\"cdk-assets --path \\\\\\"assembly-test-mijn-api/testmijnapiapistackB91CFA18.assets.json\\\\\\" --verbose publish \\\\\\"b48bcc289afb677d342a765494a81160077950d462197923711c0192c0c5941c:test-eu-west-1\\\\\\"\\"
       ]
     }
   }

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -111,7 +111,7 @@ Object {
     },
     \\"build\\": {
       \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-test-mijn-api/testmijnapicloudfrontstackB17003A6.assets.json\\\\\\" --verbose publish \\\\\\"d3c76135a48385b5665e92802a4149612e43330005c4d9eb92054bb6c812d1de:test-eu-west-1\\\\\\"\\"
+        \\"cdk-assets --path \\\\\\"assembly-test-mijn-api/testmijnapicloudfrontstackB17003A6.assets.json\\\\\\" --verbose publish \\\\\\"cc36fde147881b26584660dff21bc38d1b5f76c5613fc21141b5cfc0bbeed3a9:test-eu-west-1\\\\\\"\\"
       ]
     }
   }
@@ -350,7 +350,7 @@ Object {
     },
     \\"build\\": {
       \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-test-mijn-api/testmijnapiapistackB91CFA18.assets.json\\\\\\" --verbose publish \\\\\\"71ffaaf6a2857ba578bc3e23859bd00e27b5faef69cb279befd1e38ecf24d9d3:test-eu-west-1\\\\\\"\\"
+        \\"cdk-assets --path \\\\\\"assembly-test-mijn-api/testmijnapiapistackB91CFA18.assets.json\\\\\\" --verbose publish \\\\\\"aeee8a4b4cf311f8babf9e3792b76d56f1fc8ea182f2738e9f39ca7699b165de:test-eu-west-1\\\\\\"\\"
       ]
     }
   }
@@ -409,7 +409,7 @@ Object {
     },
     \\"build\\": {
       \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-test-mijn-api/testmijnapiapistackB91CFA18.assets.json\\\\\\" --verbose publish \\\\\\"50f268c54c53e38bc500777540494c1120c215335fc38803974d9cd7250402c3:test-eu-west-1\\\\\\"\\"
+        \\"cdk-assets --path \\\\\\"assembly-test-mijn-api/testmijnapiapistackB91CFA18.assets.json\\\\\\" --verbose publish \\\\\\"80db344122800ea26250aaa8703d9810aba1c62fa66e2f1413e6a86aa1c78c8e:test-eu-west-1\\\\\\"\\"
       ]
     }
   }
@@ -468,7 +468,7 @@ Object {
     },
     \\"build\\": {
       \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-test-mijn-api/testmijnapiapistackB91CFA18.assets.json\\\\\\" --verbose publish \\\\\\"5358f1cac8f26c76fe68e6c3efb6b1de800b64ca366861b9b9c11c7dfc14e0f0:test-eu-west-1\\\\\\"\\"
+        \\"cdk-assets --path \\\\\\"assembly-test-mijn-api/testmijnapiapistackB91CFA18.assets.json\\\\\\" --verbose publish \\\\\\"39d9bbdf80d31affd29ac7f9a5fc11c70c05a1b936489416e7cc1990e33eb8dc:test-eu-west-1\\\\\\"\\"
       ]
     }
   }
@@ -586,7 +586,7 @@ Object {
     },
     \\"build\\": {
       \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-test-mijn-api/testmijnapiapistackB91CFA18.assets.json\\\\\\" --verbose publish \\\\\\"b48bcc289afb677d342a765494a81160077950d462197923711c0192c0c5941c:test-eu-west-1\\\\\\"\\"
+        \\"cdk-assets --path \\\\\\"assembly-test-mijn-api/testmijnapiapistackB91CFA18.assets.json\\\\\\" --verbose publish \\\\\\"a4645cc2b2d692bdbeedb6a481b827aff887c10a893282a82457391f84e97785:test-eu-west-1\\\\\\"\\"
       ]
     }
   }

--- a/test/playwright/endtoend.spec.ts
+++ b/test/playwright/endtoend.spec.ts
@@ -39,7 +39,7 @@ test('Visiting main page with valid BSN shows cards', async () => {
   // Click text=Hier vindt u een overzicht van uw uitkeringen.
   const cards =  page.locator('.card');
   await expect(cards).toContainText(['Persoonsgegevens', 'Uitkeringen']);
-  await page.screenshot({ path: 'test/playwright/screenshots/home.png', fullPage: true });
+  await page.screenshot({ path: 'test/playwright/report/screenshots/home.png', fullPage: true });
 
 });
 
@@ -52,7 +52,7 @@ test('Visiting uitkeringen-page with valid BSN shows info', async () => {
   // Click text=Hier vindt u een overzicht van uw uitkeringen.
   const table =  page.locator('table tbody');
   await expect(table).toContainText('BSN van klant');
-  await page.screenshot({ path: 'test/playwright/screenshots/uitkering.png', fullPage: true });
+  await page.screenshot({ path: 'test/playwright/report/screenshots/uitkering.png', fullPage: true });
 
 });
 
@@ -66,6 +66,6 @@ test('Visiting persoonsgegevens-page with valid BSN shows info', async () => {
   // Click text=Hier vindt u een overzicht van uw uitkeringen.
   const table =  page.locator('h2');
   await expect(table).toContainText(['Persoonsgegevens', 'Adresgegevens']);
-  await page.screenshot({ path: 'test/playwright/screenshots/persoonsgegevens.png', fullPage: true });
+  await page.screenshot({ path: 'test/playwright/report/screenshots/persoonsgegevens.png', fullPage: true });
 
 });

--- a/test/playwright/endtoend.spec.ts
+++ b/test/playwright/endtoend.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect, Page } from '@playwright/test';
+
+let page: Page;
+test.beforeAll(async ({ browser }) => {
+  // Create page once and sign in.
+  page = await browser.newPage();
+  // Go to https://mijn.accp.nijmegen.nl/login
+  await page.goto('https://mijn.accp.nijmegen.nl/login');
+
+  // Click text=Inloggen via DigiD
+  await page.locator('text=Inloggen via DigiD').click();
+  await expect(page).toHaveURL('https://authenticatie-accp.nijmegen.nl/broker/select/authn');
+
+  // Click text=Simulator
+  await page.locator('text=Simulator').click();
+  await expect(page).toHaveURL('https://authenticatie-accp.nijmegen.nl/broker/authn/simulator/selection');
+
+  // Click text=DigiD >> nth=0
+  await page.locator('text=DigiD').first().click();
+  await expect(page).toHaveURL('https://authenticatie-accp.nijmegen.nl/broker/authn/simulator/authenticate/digid');
+
+  // Fill input[name="bsn"]
+  await page.locator('input[name="bsn"]').fill('900070341');
+
+  // Click [data-test="send-button"]
+  await page.locator('[data-test="send-button"]').click();
+  await expect(page).toHaveURL('https://mijn.accp.nijmegen.nl/');
+});
+
+test.afterAll(async () => {
+  await page.close();
+});
+
+test('Visiting main page with valid BSN shows cards', async () => {
+
+  // Click #navbar-collapse >> text=Uitkeringen
+  await expect(page).toHaveURL('https://mijn.accp.nijmegen.nl/');
+
+  // Click text=Hier vindt u een overzicht van uw uitkeringen.
+  const cards =  page.locator('.card');
+  await expect(cards).toContainText(['Persoonsgegevens', 'Uitkeringen']);
+  await page.screenshot({ path: 'test/playwright/screenshots/home.png', fullPage: true });
+
+});
+
+test('Visiting uitkeringen-page with valid BSN shows info', async () => {
+
+  // Click #navbar-collapse >> text=Uitkeringen
+  await page.locator('#navbar-collapse >> text=Uitkeringen').click();
+  await expect(page).toHaveURL('https://mijn.accp.nijmegen.nl/uitkeringen');
+
+  // Click text=Hier vindt u een overzicht van uw uitkeringen.
+  const table =  page.locator('table tbody');
+  await expect(table).toContainText('BSN van klant');
+  await page.screenshot({ path: 'test/playwright/screenshots/uitkering.png', fullPage: true });
+
+});
+
+
+test('Visiting persoonsgegevens-page with valid BSN shows info', async () => {
+
+  // Click #navbar-collapse >> text=Uitkeringen
+  await page.locator('#navbar-collapse >> text=Persoonsgegevens').click();
+  await expect(page).toHaveURL('https://mijn.accp.nijmegen.nl/persoonsgegevens');
+
+  // Click text=Hier vindt u een overzicht van uw uitkeringen.
+  const table =  page.locator('h2');
+  await expect(table).toContainText(['Persoonsgegevens', 'Adresgegevens']);
+  await page.screenshot({ path: 'test/playwright/screenshots/persoonsgegevens.png', fullPage: true });
+
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -699,6 +699,14 @@
   resolved "https://registry.yarnpkg.com/@oozcitak/util/-/util-8.3.8.tgz#10f65fe1891fd8cde4957360835e78fd1936bfdd"
   integrity sha512-T8TbSnGsxo6TDBJx/Sgv/BlVJL3tshxZP7Aq5R1mSnM5OcHY2dQaxLMu2+E8u3gN0MLOzdjurqN4ZRVuzQycOQ==
 
+"@playwright/test@^1.22.2":
+  version "1.22.2"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.22.2.tgz#b848f25f8918140c2d0bae8e9227a40198f2dd4a"
+  integrity sha512-cCl96BEBGPtptFz7C2FOSN3PrTnJ3rPpENe+gYCMx4GNNDlN4tmo2D89y13feGKTMMAIVrXfSQ/UmaQKLy1XLA==
+  dependencies:
+    "@types/node" "*"
+    playwright-core "1.22.2"
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -4801,6 +4809,11 @@ pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+playwright-core@1.22.2:
+  version "1.22.2"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.22.2.tgz#ed2963d79d71c2a18d5a6fd25b60b9f0a344661a"
+  integrity sha512-w/hc/Ld0RM4pmsNeE6aL/fPNWw8BWit2tg+TfqJ3+p59c6s3B6C8mXvXrIPmfQEobkcFDc+4KirNzOQ+uBSP1Q==
 
 prelude-ls@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
feat: Adds playwright tests
Adds tests (login + view various pages, check for content)
- takes screenshots
- saves screenshots
A test runner runs on PR's to accp/prod, all tests are done on the current acceptance-environment. Reports are saved to artefact-store (kept 30 days).