### PR TITLE
feat: region independence

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -2,18 +2,20 @@
 
 name: auto-merge
 on:
-  workflow_run:
-    workflows:
-      - build
+  pull_request_target:
     types:
-      - completed
+      - labeled
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
 jobs:
   automerge:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
       contents: write
-    if: github.event.workflow_run.conclusion == 'success' && contains(github.event.pull_request.labels.*.name, 'auto-merge')
+    if: contains(github.event.pull_request.labels.*.name, 'auto-merge')
     steps:
       - env:
           PR_URL: ${{github.event.pull_request.html_url}}

--- a/src/ApiStage.ts
+++ b/src/ApiStage.ts
@@ -24,7 +24,7 @@ export class ApiStage extends Stage {
     const dnsStack = new DNSStack(this, 'dns-stack', { branch: props.branch });
 
     const usEastCertificateStack = new UsEastCertificateStack(this, 'us-cert-stack', { branch: props.branch, env: { region: 'us-east-1' } });
-    const dnssecStack = new DNSSECStack(this, 'dnssec-stack', { branch: props.branch, env: { region: 'us-east-1' } });
+    const dnssecStack = new DNSSECStack(this, 'dnssec-stack', { branch: props.branch, env: { region: 'us-east-1' }, applicationRegion: this.region! });
     usEastCertificateStack.addDependency(dnsStack);
     dnssecStack.addDependency(dnsStack);
 

--- a/src/DNSSECStack.ts
+++ b/src/DNSSECStack.ts
@@ -4,7 +4,12 @@ import { Construct } from 'constructs';
 import { Statics } from './statics';
 
 export interface DNSSECStackProps extends StackProps {
-  branch: string;
+  branch: string; // TODO: Use new dnssec solution
+  /**
+   * This stack set ssm parameters, these are required
+   * in the region the application runs in.
+   */
+  applicationRegion: string;
 }
 
 export class DNSSECStack extends Stack {
@@ -27,7 +32,7 @@ export class DNSSECStack extends Stack {
 
     const parameters = new RemoteParameters(this, 'params', {
       path: `${Statics.ssmZonePath}/`,
-      region: 'eu-west-1',
+      region: props.applicationRegion,
     });
     const zoneId = parameters.get(Statics.ssmZoneIdNew);
 

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -52,7 +52,7 @@ Object {
     },
     \\"build\\": {
       \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-test-mijn-api/testmijnapicloudfrontstackB17003A6.assets.json\\\\\\" --verbose publish \\\\\\"b20ee877975fe89aad102e03735050b094985e3a38a3a230a14799a6ee2d475b:test-eu-west-1\\\\\\"\\"
+        \\"cdk-assets --path \\\\\\"assembly-test-mijn-api/testmijnapicloudfrontstackB17003A6.assets.json\\\\\\" --verbose publish \\\\\\"acf785635e04573f2215f134d9e655985323bf88476d0025f84c07c2ad97f1ca:test-eu-west-1\\\\\\"\\"
       ]
     }
   }
@@ -291,7 +291,7 @@ Object {
     },
     \\"build\\": {
       \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-test-mijn-api/testmijnapiapistackB91CFA18.assets.json\\\\\\" --verbose publish \\\\\\"a4430117545be4f87519b2547a563af8ceb0b5afea263648d71305b20cf1f107:test-eu-west-1\\\\\\"\\"
+        \\"cdk-assets --path \\\\\\"assembly-test-mijn-api/testmijnapiapistackB91CFA18.assets.json\\\\\\" --verbose publish \\\\\\"622373a8ecc2611e0dc315d9fc012209534395d445b3b7e0db36f72b0879dbab:test-eu-west-1\\\\\\"\\"
       ]
     }
   }
@@ -350,7 +350,7 @@ Object {
     },
     \\"build\\": {
       \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-test-mijn-api/testmijnapiapistackB91CFA18.assets.json\\\\\\" --verbose publish \\\\\\"57084645cdbdd40d30eec7aff5e2cad43b81d881a21339706b5bf6f041381c74:test-eu-west-1\\\\\\"\\"
+        \\"cdk-assets --path \\\\\\"assembly-test-mijn-api/testmijnapiapistackB91CFA18.assets.json\\\\\\" --verbose publish \\\\\\"3078fbe9d1c5fd9d7515ef3045a0ad983439a3e0272b18d05050b7d276892bc9:test-eu-west-1\\\\\\"\\"
       ]
     }
   }
@@ -409,7 +409,7 @@ Object {
     },
     \\"build\\": {
       \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-test-mijn-api/testmijnapiapistackB91CFA18.assets.json\\\\\\" --verbose publish \\\\\\"32a76bd5ce44dcc74952acf171dbb347c12553008d4129b9e8ca1f9c4982ef7d:test-eu-west-1\\\\\\"\\"
+        \\"cdk-assets --path \\\\\\"assembly-test-mijn-api/testmijnapiapistackB91CFA18.assets.json\\\\\\" --verbose publish \\\\\\"d08b314395ed3caec1e58aaa2cdfbd91c22b1bc13dd3dbe9db01c827a6abec6a:test-eu-west-1\\\\\\"\\"
       ]
     }
   }
@@ -468,7 +468,7 @@ Object {
     },
     \\"build\\": {
       \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-test-mijn-api/testmijnapiapistackB91CFA18.assets.json\\\\\\" --verbose publish \\\\\\"9f6e2990ab8f0d2344577bb4fabbe88691b5dfda2321bbd571f9504b3a6507f2:test-eu-west-1\\\\\\"\\"
+        \\"cdk-assets --path \\\\\\"assembly-test-mijn-api/testmijnapiapistackB91CFA18.assets.json\\\\\\" --verbose publish \\\\\\"432f4456f851e4d60f9e2d4c134973e4fa2481e4069a800436ec0ac0d6a5140b:test-eu-west-1\\\\\\"\\"
       ]
     }
   }

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -52,7 +52,7 @@ Object {
     },
     \\"build\\": {
       \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-test-mijn-api/testmijnapicloudfrontstackB17003A6.assets.json\\\\\\" --verbose publish \\\\\\"acf785635e04573f2215f134d9e655985323bf88476d0025f84c07c2ad97f1ca:test-eu-west-1\\\\\\"\\"
+        \\"cdk-assets --path \\\\\\"assembly-test-mijn-api/testmijnapicloudfrontstackB17003A6.assets.json\\\\\\" --verbose publish \\\\\\"b20ee877975fe89aad102e03735050b094985e3a38a3a230a14799a6ee2d475b:test-eu-west-1\\\\\\"\\"
       ]
     }
   }
@@ -291,7 +291,7 @@ Object {
     },
     \\"build\\": {
       \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-test-mijn-api/testmijnapiapistackB91CFA18.assets.json\\\\\\" --verbose publish \\\\\\"622373a8ecc2611e0dc315d9fc012209534395d445b3b7e0db36f72b0879dbab:test-eu-west-1\\\\\\"\\"
+        \\"cdk-assets --path \\\\\\"assembly-test-mijn-api/testmijnapiapistackB91CFA18.assets.json\\\\\\" --verbose publish \\\\\\"a4430117545be4f87519b2547a563af8ceb0b5afea263648d71305b20cf1f107:test-eu-west-1\\\\\\"\\"
       ]
     }
   }
@@ -350,7 +350,7 @@ Object {
     },
     \\"build\\": {
       \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-test-mijn-api/testmijnapiapistackB91CFA18.assets.json\\\\\\" --verbose publish \\\\\\"3078fbe9d1c5fd9d7515ef3045a0ad983439a3e0272b18d05050b7d276892bc9:test-eu-west-1\\\\\\"\\"
+        \\"cdk-assets --path \\\\\\"assembly-test-mijn-api/testmijnapiapistackB91CFA18.assets.json\\\\\\" --verbose publish \\\\\\"57084645cdbdd40d30eec7aff5e2cad43b81d881a21339706b5bf6f041381c74:test-eu-west-1\\\\\\"\\"
       ]
     }
   }
@@ -409,7 +409,7 @@ Object {
     },
     \\"build\\": {
       \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-test-mijn-api/testmijnapiapistackB91CFA18.assets.json\\\\\\" --verbose publish \\\\\\"d08b314395ed3caec1e58aaa2cdfbd91c22b1bc13dd3dbe9db01c827a6abec6a:test-eu-west-1\\\\\\"\\"
+        \\"cdk-assets --path \\\\\\"assembly-test-mijn-api/testmijnapiapistackB91CFA18.assets.json\\\\\\" --verbose publish \\\\\\"32a76bd5ce44dcc74952acf171dbb347c12553008d4129b9e8ca1f9c4982ef7d:test-eu-west-1\\\\\\"\\"
       ]
     }
   }
@@ -468,7 +468,7 @@ Object {
     },
     \\"build\\": {
       \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-test-mijn-api/testmijnapiapistackB91CFA18.assets.json\\\\\\" --verbose publish \\\\\\"432f4456f851e4d60f9e2d4c134973e4fa2481e4069a800436ec0ac0d6a5140b:test-eu-west-1\\\\\\"\\"
+        \\"cdk-assets --path \\\\\\"assembly-test-mijn-api/testmijnapiapistackB91CFA18.assets.json\\\\\\" --verbose publish \\\\\\"9f6e2990ab8f0d2344577bb4fabbe88691b5dfda2321bbd571f9504b3a6507f2:test-eu-west-1\\\\\\"\\"
       ]
     }
   }


### PR DESCRIPTION
This stack exports some ssm parameters to the application region. This was hardcoded as eu-west-1. It now uses the parent stage region.