### PR TITLE
fix: only init apiclient once

### DIFF
--- a/src/ApiFunction.ts
+++ b/src/ApiFunction.ts
@@ -25,7 +25,7 @@ export class ApiFunction extends Construct {
     // See https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Lambda-Insights-extension-versionsx86-64.html
     const insightsArn = 'arn:aws:lambda:eu-west-1:580247275435:layer:LambdaInsightsExtension:16';
     this.lambda = new Lambda.Function(this, 'lambda', {
-      runtime: Lambda.Runtime.NODEJS_14_X,
+      runtime: Lambda.Runtime.NODEJS_18_X,
       memorySize: 512,
       handler: 'index.handler',
       description: props.description,

--- a/src/app/auth/index.js
+++ b/src/app/auth/index.js
@@ -1,8 +1,11 @@
 const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
+const { ApiClient } = require('@gemeentenijmegen/apiclient');
 const { Response } = require('@gemeentenijmegen/apigateway-http/lib/V2/Response');
 const { handleRequest } = require("./handleRequest");
 
 const dynamoDBClient = new DynamoDBClient();
+const apiClient = new ApiClient();
+await apiClient.init();
 
 function parseEvent(event) {
     return { 
@@ -15,7 +18,7 @@ function parseEvent(event) {
 exports.handler = async (event, context) => {
     try {
         const params = parseEvent(event);
-        return await handleRequest(params.cookies, params.code, params.state, dynamoDBClient);
+        return await handleRequest(params.cookies, params.code, params.state, dynamoDBClient, apiClient);
     } catch (err) {
         console.error(err);
         return Response.error(500);


### PR DESCRIPTION
I suspect the secret was retrieved for every request. This inits the apiClient once, and reuses it for each request.

Fixes #