### PR TITLE
feat: allow yivi attributes

### DIFF
--- a/src/app/auth/handleRequest.ts
+++ b/src/app/auth/handleRequest.ts
@@ -30,6 +30,9 @@ export async function handleRequest(props: requestProps) {
     const claims = await props.OpenIdConnect.authorize(props.queryStringParamCode, state, props.queryStringParamState);
     if (claims) {
       const bsn = bsnFromClaims(claims);
+      if(!bsn) {
+        return Response.redirect('/login');
+      }
       if (claims.hasOwnProperty('acr')) {
         logger.info('auth succesful', { loa: claims.acr });
       }

--- a/src/app/auth/handleRequest.ts
+++ b/src/app/auth/handleRequest.ts
@@ -4,9 +4,9 @@ import { ApiClient } from '@gemeentenijmegen/apiclient';
 import { Response } from '@gemeentenijmegen/apigateway-http/lib/V2/Response';
 import { Session } from '@gemeentenijmegen/session';
 import { Bsn } from '@gemeentenijmegen/utils';
+import { IdTokenClaims } from 'openid-client';
 import { BrpApi } from './BrpApi';
 import { OpenIDConnect } from '../../shared/OpenIDConnect';
-import { IdTokenClaims } from 'openid-client';
 
 interface requestProps {
   cookies: string;
@@ -30,7 +30,7 @@ export async function handleRequest(props: requestProps) {
     const claims = await props.OpenIdConnect.authorize(props.queryStringParamCode, state, props.queryStringParamState);
     if (claims) {
       const bsn = bsnFromClaims(claims);
-      if(!bsn) {
+      if (!bsn) {
         return Response.redirect('/login');
       }
       if (claims.hasOwnProperty('acr')) {
@@ -72,22 +72,22 @@ async function loggedinUserName(bsn: string, apiClient: ApiClient) {
 
 /**
  * Extract bsn from token claims
- * 
+ *
  * The bsn can be found in several fields: either the 'sub' claim
  * or a yivi-specific field can be used. This function tries (in order)
  * to get a valid BSN from:
  * - sub
  * - pbdf.gemeente.bsn.bsn
  * - irma-demo.gemeente.personalData.bsn
- * 
+ *
  * @param claims an IdTokenClaims object
  * @returns {BSN|false}
  */
 export function bsnFromClaims(claims: IdTokenClaims): Bsn|false {
   const possibleClaims = ['sub', 'pbdf.gemeente.bsn.bsn', 'irma-demo.gemeente.personalData.bsn'];
-  for(const type of possibleClaims) {
+  for (const type of possibleClaims) {
     try {
-      if(claims[type]) {
+      if (claims[type]) {
         return new Bsn(claims[type] as string);
       }
     } catch (error: any) {

--- a/src/app/auth/handleRequest.ts
+++ b/src/app/auth/handleRequest.ts
@@ -6,6 +6,7 @@ import { Session } from '@gemeentenijmegen/session';
 import { Bsn } from '@gemeentenijmegen/utils';
 import { BrpApi } from './BrpApi';
 import { OpenIDConnect } from '../../shared/OpenIDConnect';
+import { IdTokenClaims } from 'openid-client';
 
 interface requestProps {
   cookies: string;
@@ -28,7 +29,7 @@ export async function handleRequest(props: requestProps) {
   try {
     const claims = await props.OpenIdConnect.authorize(props.queryStringParamCode, state, props.queryStringParamState);
     if (claims) {
-      const bsn = new Bsn(claims.sub);
+      const bsn = bsnFromClaims(claims);
       if (claims.hasOwnProperty('acr')) {
         logger.info('auth succesful', { loa: claims.acr });
       }
@@ -64,4 +65,31 @@ async function loggedinUserName(bsn: string, apiClient: ApiClient) {
     console.error('Error getting username');
     return 'Onbekende gebruiker';
   }
+}
+
+/**
+ * Extract bsn from token claims
+ * 
+ * The bsn can be found in several fields: either the 'sub' claim
+ * or a yivi-specific field can be used. This function tries (in order)
+ * to get a valid BSN from:
+ * - sub
+ * - pbdf.gemeente.bsn.bsn
+ * - irma-demo.gemeente.personalData.bsn
+ * 
+ * @param claims an IdTokenClaims object
+ * @returns {BSN|false}
+ */
+export function bsnFromClaims(claims: IdTokenClaims): Bsn|false {
+  const possibleClaims = ['sub', 'pbdf.gemeente.bsn.bsn', 'irma-demo.gemeente.personalData.bsn'];
+  for(const type of possibleClaims) {
+    try {
+      if(claims[type]) {
+        return new Bsn(claims[type] as string);
+      }
+    } catch (error: any) {
+      // we don't care about non-valid BSN's (sub could have a random string)
+    }
+  }
+  return false;
 }

--- a/src/app/auth/tests/auth.test.ts
+++ b/src/app/auth/tests/auth.test.ts
@@ -1,13 +1,13 @@
 import { DynamoDBClient, GetItemCommand, GetItemCommandOutput } from '@aws-sdk/client-dynamodb';
 import { SecretsManagerClient, GetSecretValueCommandOutput, GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
 import { ApiClient } from '@gemeentenijmegen/apiclient';
+import { Bsn } from '@gemeentenijmegen/utils';
 import { mockClient } from 'aws-sdk-client-mock';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
+import { IdTokenClaims } from 'openid-client';
 import { OpenIDConnect } from '../../../shared/OpenIDConnect';
 import { bsnFromClaims, handleRequest } from '../handleRequest';
-import { IdTokenClaims } from 'openid-client';
-import { Bsn } from '@gemeentenijmegen/utils';
 
 
 function mockedOidcClient(authorized = true) {
@@ -139,14 +139,14 @@ test('No session redirects to login', async () => {
 });
 
 describe('Get bsn from claims object', () => {
-  const claims: IdTokenClaims = {
-    aud: 'test',
-    exp: 123,
-    iat: 123,
-    iss: 'test',
-    sub: '900222670',
-  };
   test('bsn in sub', async () => {
+    const claims: IdTokenClaims = {
+      aud: 'test',
+      exp: 123,
+      iat: 123,
+      iss: 'test',
+      sub: '900222670',
+    };
     const bsn = bsnFromClaims(claims);
     expect(bsn).toBeInstanceOf(Bsn);
     expect(bsn).toBeTruthy();
@@ -161,7 +161,7 @@ describe('Get bsn from claims object', () => {
       iat: 123,
       iss: 'test',
       sub: 'test',
-      [`irma-demo.gemeente.personalData.bsn`]: '900070341'
+      ['irma-demo.gemeente.personalData.bsn']: '900070341',
     };
     const bsn = bsnFromClaims(claims);
     expect(bsn).toBeInstanceOf(Bsn);
@@ -178,7 +178,7 @@ describe('Get bsn from claims object', () => {
       iat: 123,
       iss: 'test',
       sub: 'test',
-      [`pbdf.gemeente.bsn.bsn`]: '900070341'
+      ['pbdf.gemeente.bsn.bsn']: '900070341',
     };
     const bsn = bsnFromClaims(claims);
     expect(bsn).toBeInstanceOf(Bsn);
@@ -187,7 +187,7 @@ describe('Get bsn from claims object', () => {
       expect(bsn.bsn).toBe('900070341');
     }
   });
-  
+
   test('bsn in sub and irma-demo.gemeente.personalData.bsn uses first', async () => {
     const claims: IdTokenClaims = {
       aud: 'test',
@@ -195,7 +195,7 @@ describe('Get bsn from claims object', () => {
       iat: 123,
       iss: 'test',
       sub: '900222670',
-      [`irma-demo.gemeente.personalData.bsn`]: '900070341'
+      ['irma-demo.gemeente.personalData.bsn']: '900070341',
     };
     const bsn = bsnFromClaims(claims);
     expect(bsn).toBeInstanceOf(Bsn);


### PR DESCRIPTION
The bsn can be found in several fields: either the 'sub' claim
or a yivi-specific field can be used. This addition tries (in order)
to get a valid BSN from:
- sub
- pbdf.gemeente.bsn.bsn
- irma-demo.gemeente.personalData.bsn