### PR TITLE
feat: Underline links by default

### DIFF
--- a/src/app/static-resources/.well-known/security.txt
+++ b/src/app/static-resources/.well-known/security.txt
@@ -3,5 +3,5 @@ Expires: 2023-12-31T22:59:00.000Z
 Encryption: https://app4.nijmegen.nl/pgp-key.txt
 Acknowledgments: https://www.nijmegen.nl/diensten/privacy/beveiligings-of-datalek-melden/
 Preferred-Languages: NL
-Canonical: https://mijn.nijmegen.nl/.well-known/security.txt
+Canonical: https://www.nijmegen.nl/.well-known/security.txt
 Policy: https://www.nijmegen.nl/diensten/privacy/beveiligings-of-datalek-melden/

--- a/src/app/static-resources/static/styles/screen.css
+++ b/src/app/static-resources/static/styles/screen.css
@@ -76,6 +76,14 @@ body {
     padding-top: 150px;
 }
 
+body a {
+    text-decoration: underline;
+}
+
+.btn, .navbar a {
+    text-decoration: none;
+}
+
 main {
     min-height: 50vh;
 }


### PR DESCRIPTION
The default link styling in the stylesheet is not underlined. Text links should be underlined, but in the context of the component library, they are only underlined in .text-content elements.

This PR changes the default to underlined, and overrides this for the navbar and button-styled links.

Fixes #