### PR TITLE
fix: Logo position on scroll

### DIFF
--- a/src/app/static-resources/static/styles/screen.css
+++ b/src/app/static-resources/static/styles/screen.css
@@ -88,6 +88,11 @@ main {
     min-height: 50vh;
 }
 
+/** Fix for issue in safari, not in component library **/
+.navbar-brand .logo {
+    top: 0;
+}
+
 .btn-digid {
     background-image: url(../images/digid.svg);
     background-repeat: no-repeat;


### PR DESCRIPTION
The text-less logo displayed incorrectly in safari, this fixes the positioning. This is not yet added to the component library.
issue: <img width="323" alt="logo showing over text content below header instead of in header" src="https://github.com/GemeenteNijmegen/mijn-nijmegen/assets/992731/f666c809-05bd-4689-bca4-ae4e838e5044">