### PR TITLE
feat: Add 2fa info text to login screen

### DIFF
--- a/src/app/login/templates/login-yivi.mustache
+++ b/src/app/login/templates/login-yivi.mustache
@@ -6,12 +6,19 @@
         <h1>Inloggen Mijn Nijmegen</h1>
         <p class="lead">U kunt kiezen om met DigiD in te loggen of met Yivi.</p>
         <div class="login-selector">
-            <a href="{{{authUrlDigid}}}" class="btn btn-primary waves-effect waves-light display-table btn-digid">
-                <span class="title"> Inloggen </span><span class="assistive">met DigiD</span>
-            </a>
-            <a href="{{{authUrlYivi}}}" class="btn btn-primary waves-effect waves-light display-table btn-yivi">
-                <span class="title"> Inloggen </span><span class="assistive">met Yivi</span>
-            </a>
+            <div>
+                <a href="{{{authUrlDigid}}}" class="btn btn-primary waves-effect waves-light display-table btn-digid">
+                    <span class="title"> Inloggen </span><span class="assistive">met DigiD</span>
+                </a>
+                <div class="info">
+                    <svg class="mdi mdi-information" aria-hidden="true" viewBox="0 0 24 24" width="24" height="24" xmlns="http://www.w3.org/2000/svg"><path d="m13 9h-2v-2h2m0 10h-2v-6h2m-1-9a10 10 0 0 0 -10 10 10 10 0 0 0 10 10 10 10 0 0 0 10-10 10 10 0 0 0 -10-10z"/></svg>Vanaf <strong>1 augustus</strong> kunt u alleen nog inloggen met de DigiD-app of in 2 stappen met gebruikersnaam en een sms-code. U kunt dan niet meer inloggen met alleen uw gebruikersnaam en wachtwoord.
+                </div>
+            </div>
+            <div>
+                <a href="{{{authUrlYivi}}}" class="btn btn-primary waves-effect waves-light display-table btn-yivi">
+                    <span class="title"> Inloggen </span><span class="assistive">met Yivi</span>
+                </a>
+            </div>
         </div>
         <p>Door in te loggen geeft u uw BSN (BurgerServiceNummer) door. Dit is een uniek nummer waaraan uw persoonlijke gegevens zijn gekoppeld. Wij vragen uw BSN zodat u alleen uw gegevens ziet. Met Yivi ziet u welke gegevens van u gevraagd worden als u inlogt. <a href="https://www.nijmegen.nl/diensten/privacy/yivi-nieuwe-manier-van-inloggen/">Lees meer over Yivi</a>.
     </div>

--- a/src/app/static-resources/static/styles/screen.css
+++ b/src/app/static-resources/static/styles/screen.css
@@ -174,6 +174,18 @@ main {
   flex-basis: 100%;
 }
 
+.login-selector a {
+    display: block;
+}
+
+.login-selector .info {
+    background: #40c4ff;
+    color: black;
+    padding: .5em 1em;
+    margin: 1em .5em .5em .5em;
+    border-radius: 2px;
+}
+
 table {
     margin-bottom: 2rem;
 }
@@ -210,4 +222,3 @@ footer.page-footer {
 .md-form label {
     left: initial;
 }
-


### PR DESCRIPTION
Starting 1-8, we will require 2fa for Digid logins. This feature adds an info text to the login page warning users of this change.

Fixes #549 