### PR TITLE
feat: s3 object ownership

### DIFF
--- a/src/CloudfrontStack.ts
+++ b/src/CloudfrontStack.ts
@@ -233,6 +233,7 @@ export class CloudfrontStack extends Stack {
       eventBridgeEnabled: true,
       enforceSSL: true,
       encryption: S3.BucketEncryption.S3_MANAGED,
+      objectOwnership: S3.ObjectOwnership.OBJECT_WRITER,
       lifecycleRules: [
         {
           id: 'delete objects after 180 days',


### PR DESCRIPTION
Fixes issue
```
Resource handler returned message: "Invalid request provided:
AWS::CloudFront::Distribution: The S3 bucket that you specified for
CloudFront logs does not enable ACL access:
mijn-api-cloudfront-stack-cloudfrontlogs```
