### PR TITLE
feat: use a config object in the new lz setup

### DIFF
--- a/src/ApiStage.ts
+++ b/src/ApiStage.ts
@@ -3,6 +3,7 @@ import { Aspects, Stage, StageProps, Tags } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { ApiStack } from './ApiStack';
 import { CloudfrontStack } from './CloudfrontStack';
+import { Configurable } from './Configuration';
 import { DNSSECStack } from './DNSSECStack';
 import { DNSStack } from './DNSStack';
 import { KeyStack } from './keystack';
@@ -11,9 +12,7 @@ import { Statics } from './statics';
 import { UsEastCertificateStack } from './UsEastCertificateStack';
 import { WafStack } from './WafStack';
 
-export interface ApiStageProps extends StageProps {
-  branch: string;
-}
+export interface ApiStageProps extends StageProps, Configurable {}
 
 /**
  * Stage responsible for the API Gateway and lambdas
@@ -26,26 +25,27 @@ export class ApiStage extends Stage {
     Tags.of(this).add('Project', Statics.projectName);
     Aspects.of(this).add(new PermissionsBoundaryAspect());
 
+    const branchName = props.configuration.branch;
 
     const keyStack = new KeyStack(this, 'key-stack');
     const sessionsStack = new SessionsStack(this, 'sessions-stack', { key: keyStack.key });
-    const dnsStack = new DNSStack(this, 'dns-stack', { branch: props.branch });
+    const dnsStack = new DNSStack(this, 'dns-stack', { configuration: props.configuration });
 
-    const usEastCertificateStack = new UsEastCertificateStack(this, 'us-cert-stack', { branch: props.branch, env: { region: 'us-east-1' } });
-    const dnssecStack = new DNSSECStack(this, 'dnssec-stack', { branch: props.branch, env: { region: 'us-east-1' }, applicationRegion: this.region! });
+    const usEastCertificateStack = new UsEastCertificateStack(this, 'us-cert-stack', { branch: branchName, env: { region: 'us-east-1' } });
+    const dnssecStack = new DNSSECStack(this, 'dnssec-stack', { branch: branchName, env: { region: 'us-east-1' }, applicationRegion: this.region! });
     usEastCertificateStack.addDependency(dnsStack);
     dnssecStack.addDependency(dnsStack);
 
     const apistack = new ApiStack(this, 'api-stack', {
-      branch: props.branch,
+      branch: branchName,
       sessionsTable: sessionsStack.sessionsTable,
     });
     const cloudfrontStack = new CloudfrontStack(this, 'cloudfront-stack', {
-      branch: props.branch,
+      branch: branchName,
       hostDomain: apistack.domain(),
     });
     cloudfrontStack.addDependency(usEastCertificateStack);
 
-    new WafStack(this, 'waf-stack', { env: { region: 'us-east-1' }, branch: props.branch });
+    new WafStack(this, 'waf-stack', { env: { region: 'us-east-1' }, branch: branchName });
   }
 }

--- a/src/CloudfrontStack.ts
+++ b/src/CloudfrontStack.ts
@@ -62,7 +62,7 @@ export class CloudfrontStack extends Stack {
      * to overkill for us. See: https://repost.aws/knowledge-center/resolve-cnamealreadyexists-error
      * We'll switch manually, sorry.
      */
-    if(props.branch.endsWith('-new-lz')) {
+    if (props.branch.endsWith('-new-lz')) {
       console.warn('Keeping out the nijmegen.nl domain (CloudFront alternative name conflicts workaround)');
     } else {
       domains.push(mainDomain);

--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -1,0 +1,77 @@
+import { Statics } from './statics';
+
+/**
+ * Adds a configuration field to another interface
+ */
+export interface Configurable {
+  configuration: Configuration;
+}
+
+/**
+ * Environment object (required fields)
+ */
+export interface Environment {
+  account: string;
+  region: string;
+}
+
+/**
+ * Basic configuration options per environment
+ */
+export interface Configuration {
+  /**
+   * Branch name for the applicible branch (this branch)
+   */
+  branch: string;
+
+  /**
+   * Environment to place the pipeline
+   */
+  buildEnvironment: Environment;
+
+  /**
+   * Environment to deploy the application
+   */
+  deploymentEnvironment: Environment;
+
+  /**
+   * CNAME records to deploy in the hosted zone
+   */
+  cnameRecords?: { [key: string]: string };
+
+  /**
+   * A DS record (value) to deploy in the hosted zone
+   */
+  dsRecord?: string;
+}
+
+
+const EnvironmentConfigurations: {[key:string]: Configuration} = {
+  'acceptance-new-lz': {
+    branch: 'acceptance-new-lz',
+    buildEnvironment: Statics.gnBuildEnvironment,
+    deploymentEnvironment: Statics.gnMijnNijmegenAccpEnvironment,
+    cnameRecords: {
+      _554c359f26fbc43f02d85e43dccd6336: '_430b5afffdedea75381eaec545e8189c.vrcmzfbvtx.acm-validations.aws.',
+    },
+    dsRecord: '3766 13 2 11761745E09473E6CE95DB798CF1ADB69B4433E73EEFC9F7FE341561966EA154',
+  },
+  'production-new-lz': {
+    branch: 'production-new-lz',
+
+    buildEnvironment: Statics.gnBuildEnvironment,
+    deploymentEnvironment: Statics.gnMijnNijmegenProdEnvironment,
+    cnameRecords: {
+      _abe87d0d7f8458c5f75c5d1e0bf6efdb: '_0d3e717e52354c47bf6b0c16612b709d.jzckvmdcqj.acm-validations.aws.',
+    },
+    dsRecord: '40951 13 2 1EFF20C0264CD1FDE6C7C858398BC2141768CC014A7BB27997F323076B7C47ED',
+  },
+};
+
+export function getEnvironmentConfiguration(branchName: string) {
+  const conf = EnvironmentConfigurations[branchName];
+  if (!conf) {
+    throw Error(`No configuration found for branch ${branchName}`);
+  }
+  return conf;
+}

--- a/src/DNSStack.ts
+++ b/src/DNSStack.ts
@@ -1,10 +1,10 @@
+import * as crypto from 'crypto';
 import { aws_route53 as Route53, Stack, StackProps, aws_ssm as SSM, Duration } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
+import { Configurable } from './Configuration';
 import { Statics } from './statics';
 
-export interface DNSStackProps extends StackProps {
-  branch: string;
-}
+export interface DNSStackProps extends StackProps, Configurable { }
 
 export class DNSStack extends Stack {
   zone: Route53.HostedZone;
@@ -13,7 +13,7 @@ export class DNSStack extends Stack {
 
   constructor(scope: Construct, id: string, props: DNSStackProps) {
     super(scope, id);
-    this.branch = props.branch;
+    this.branch = props.configuration.branch;
 
     const rootZoneId = SSM.StringParameter.valueForStringParameter(this, Statics.accountRootHostedZoneId);
     const rootZoneName = SSM.StringParameter.valueForStringParameter(this, Statics.accountRootHostedZoneName);
@@ -29,7 +29,8 @@ export class DNSStack extends Stack {
 
     this.addZoneIdAndNametoParams();
     this.addNSToRootCSPzone();
-    this.addDsRecord();
+    this.addDsRecord(props.configuration.dsRecord);
+    this.addCnameRecords(props.configuration.cnameRecords);
 
   }
 
@@ -80,19 +81,7 @@ export class DNSStack extends Stack {
    * Add DS record for the zone to the parent zone
    * to establish a chain of trust (https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-configuring-dnssec-enable-signing.html#dns-configuring-dnssec-chain-of-trust)
    */
-  addDsRecord() {
-    let dsValue = undefined;
-    switch (this.branch) {
-      case 'acceptance':
-        dsValue = '52561 13 2 90CF3C35FDDC30AF42FB4BCCDCCB1123500050D70F1D4886D6DE25502F3BC50A';
-        break;
-      case 'production':
-        dsValue = '60066 13 2 932CD585B029E674E17C4C33DFE7DE2C84353ACD8C109760FD17A6CDBD0CF3FA';
-        break;
-      default:
-        break;
-    }
-
+  addDsRecord(dsValue?: string) {
     if (!dsValue) {
       return; // Skip DS record creation if there is no value.
     }
@@ -102,6 +91,21 @@ export class DNSStack extends Stack {
       recordName: 'mijn',
       values: [dsValue],
       ttl: Duration.seconds(600),
+    });
+  }
+
+  addCnameRecords(cnameRecords?: { [key: string]: string }) {
+    if (!cnameRecords) {
+      return; // No records to define
+    }
+
+    Object.entries(cnameRecords).forEach(record => {
+      const hash = crypto.createHash('md5').update(`${record[0]}${record[1]}`).digest('hex').substring(0, 10);
+      new Route53.CnameRecord(this, `cname-record-${hash}`, {
+        recordName: record[0],
+        domainName: record[1],
+        zone: this.zone,
+      });
     });
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,90 +1,17 @@
 import { App } from 'aws-cdk-lib';
 import * as Dotenv from 'dotenv';
+import { getEnvironmentConfiguration } from './Configuration';
 import { PipelineStack } from './PipelineStack';
-import { PipelineStackAcceptance } from './PipelineStackAcceptance';
-import { PipelineStackDevelopment } from './PipelineStackDevelopment';
-import { PipelineStackProduction } from './PipelineStackProduction';
-
-// for development, use sandbox account
-const deploymentEnvironment = {
-  account: '418648875085',
-  region: 'eu-west-1',
-};
-
-const sandboxEnvironment = {
-  account: '122467643252',
-  region: 'eu-west-1',
-};
-
-const acceptanceEnvironment = {
-  account: '315037222840',
-  region: 'eu-west-1',
-};
-
-const productionEnvironment = {
-  account: '196212984627',
-  region: 'eu-west-1',
-};
-
-const gnBuildEnvironment = {
-  account: '836443378780',
-  region: 'eu-central-1',
-};
-
-const gnMijnNijmegenAccpEnvironment = {
-  account: '021929636313',
-  region: 'eu-central-1',
-};
-
-const gnMijnNijmegenProdEnvironment = {
-  account: '740606269759',
-  region: 'eu-central-1',
-};
 
 Dotenv.config();
 const app = new App();
 
+const branchToBuild = process.env.BRANCH_NAME ?? 'development';
+const configuration = getEnvironmentConfiguration(branchToBuild);
 
-if ('BRANCH_NAME' in process.env == false || process.env.BRANCH_NAME == 'development') {
-  new PipelineStackDevelopment(app, 'mijnuitkering-pipeline-development',
-    {
-      env: deploymentEnvironment,
-      branchName: 'development',
-      deployToEnvironment: sandboxEnvironment,
-    },
-  );
-} else if (process.env.BRANCH_NAME == 'acceptance') {
-  new PipelineStackAcceptance(app, 'mijnuitkering-pipeline-acceptance',
-    {
-      env: deploymentEnvironment,
-      branchName: 'acceptance',
-      deployToEnvironment: acceptanceEnvironment,
-    },
-  );
-} else if (process.env.BRANCH_NAME == 'acceptance-new-lz') {
-  new PipelineStack(app, 'mijnuitkering-pipeline-acceptance-new-lz',
-    {
-      env: gnBuildEnvironment,
-      branchName: 'acceptance-new-lz',
-      deployToEnvironment: gnMijnNijmegenAccpEnvironment,
-    },
-  );
-} else if (process.env.BRANCH_NAME == 'production') {
-  new PipelineStackProduction(app, 'mijnuitkering-pipeline-production',
-    {
-      env: deploymentEnvironment,
-      branchName: 'production',
-      deployToEnvironment: productionEnvironment,
-    },
-  );
-} else if (process.env.BRANCH_NAME == 'production-new-lz') {
-  new PipelineStack(app, 'mijnuitkering-pipeline-production-new-lz',
-    {
-      env: gnBuildEnvironment,
-      branchName: 'production-new-lz',
-      deployToEnvironment: gnMijnNijmegenProdEnvironment,
-    },
-  );
-}
+new PipelineStack(app, `mijnuitkering-pipeline-${configuration.branch}`, {
+  env: configuration.buildEnvironment,
+  configuration: configuration,
+});
 
 app.synth();

--- a/src/statics.ts
+++ b/src/statics.ts
@@ -113,6 +113,43 @@ export abstract class Statics {
   static readonly ssmSlackWebhookUrl: string = '/cdk/mijn-nijmegen/slack-webhook-url';
 
 
+  // ENVIRONMENTS
+
+  static readonly deploymentEnvironment = {
+    account: '418648875085',
+    region: 'eu-west-1',
+  };
+
+  static readonly sandboxEnvironment = {
+    account: '122467643252',
+    region: 'eu-west-1',
+  };
+
+  static readonly acceptanceEnvironment = {
+    account: '315037222840',
+    region: 'eu-west-1',
+  };
+
+  static readonly productionEnvironment = {
+    account: '196212984627',
+    region: 'eu-west-1',
+  };
+
+  static readonly gnBuildEnvironment = {
+    account: '836443378780',
+    region: 'eu-central-1',
+  };
+
+  static readonly gnMijnNijmegenAccpEnvironment = {
+    account: '021929636313',
+    region: 'eu-central-1',
+  };
+
+  static readonly gnMijnNijmegenProdEnvironment = {
+    account: '740606269759',
+    region: 'eu-central-1',
+  };
+
   static subDomain(branch: string) {
     const subdomainMap = {
       'acceptance': 'mijn.accp',


### PR DESCRIPTION
- Add config object
- Add configurable interface
- Simplify main file
- Use config object in pipeline stack, api stage and dns stack.
- Update tests

Warning 🚨: this introduces more differences between the old lz and new lz. In addition to the existing changes to prepare for the new lz. 