### PR TITLE
feat: use a config object in the new lz setup

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -141,6 +141,10 @@
       "type": "runtime"
     },
     {
+      "name": "@gemeentenijmegen/aws-constructs",
+      "type": "runtime"
+    },
+    {
       "name": "@gemeentenijmegen/projen-project-type",
       "type": "runtime"
     },

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -9,6 +9,7 @@ const project = new GemeenteNijmegenCdkApp({
     '@aws-sdk/client-dynamodb',
     '@aws-sdk/client-secrets-manager',
     '@gemeentenijmegen/projen-project-type',
+    '@gemeentenijmegen/aws-constructs',
     '@gemeentenijmegen/apiclient',
     '@gemeentenijmegen/apigateway-http',
     '@gemeentenijmegen/session',

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@aws-solutions-constructs/aws-lambda-dynamodb": "^2.41.0",
     "@gemeentenijmegen/apiclient": "^0.0.5",
     "@gemeentenijmegen/apigateway-http": "^0.0.6",
+    "@gemeentenijmegen/aws-constructs": "^0.0.4",
     "@gemeentenijmegen/projen-project-type": "^1.5.2",
     "@gemeentenijmegen/session": "^0.0.7",
     "@gemeentenijmegen/utils": "^0.0.4",

--- a/src/ApiFunction.ts
+++ b/src/ApiFunction.ts
@@ -1,4 +1,4 @@
-import { aws_lambda as Lambda, aws_dynamodb, aws_ssm as SSM, RemovalPolicy, Duration } from 'aws-cdk-lib';
+import { aws_lambda as Lambda, aws_dynamodb, aws_ssm as SSM, RemovalPolicy, Duration, Stack } from 'aws-cdk-lib';
 import { Alarm } from 'aws-cdk-lib/aws-cloudwatch';
 import { Role } from 'aws-cdk-lib/aws-iam';
 import { FilterPattern, IFilterPattern, MetricFilter, RetentionDays } from 'aws-cdk-lib/aws-logs';
@@ -26,7 +26,7 @@ export class ApiFunction extends Construct {
   constructor(scope: Construct, id: string, props: ApiFunctionProps) {
     super(scope, id);
     // See https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Lambda-Insights-extension-versionsx86-64.html
-    const insightsArn = 'arn:aws:lambda:eu-west-1:580247275435:layer:LambdaInsightsExtension:21';
+    const insightsArn = `arn:aws:lambda:${Stack.of(this).region}:580247275435:layer:LambdaInsightsExtension:21`;
     this.lambda = new props.apiFunction(this, 'lambda', {
       runtime: Lambda.Runtime.NODEJS_18_X,
       memorySize: 512,

--- a/src/ApiStage.ts
+++ b/src/ApiStage.ts
@@ -1,4 +1,5 @@
-import { Stage, StageProps } from 'aws-cdk-lib';
+import { PermissionsBoundaryAspect } from '@gemeentenijmegen/aws-constructs';
+import { Aspects, Stage, StageProps, Tags } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { ApiStack } from './ApiStack';
 import { CloudfrontStack } from './CloudfrontStack';
@@ -6,6 +7,7 @@ import { DNSSECStack } from './DNSSECStack';
 import { DNSStack } from './DNSStack';
 import { KeyStack } from './keystack';
 import { SessionsStack } from './SessionsStack';
+import { Statics } from './statics';
 import { UsEastCertificateStack } from './UsEastCertificateStack';
 import { WafStack } from './WafStack';
 
@@ -19,6 +21,12 @@ export interface ApiStageProps extends StageProps {
 export class ApiStage extends Stage {
   constructor(scope: Construct, id: string, props: ApiStageProps) {
     super(scope, id, props);
+
+    Tags.of(this).add('cdkManaged', 'yes');
+    Tags.of(this).add('Project', Statics.projectName);
+    Aspects.of(this).add(new PermissionsBoundaryAspect());
+
+
     const keyStack = new KeyStack(this, 'key-stack');
     const sessionsStack = new SessionsStack(this, 'sessions-stack', { key: keyStack.key });
     const dnsStack = new DNSStack(this, 'dns-stack', { branch: props.branch });

--- a/src/ApiStage.ts
+++ b/src/ApiStage.ts
@@ -3,6 +3,7 @@ import { Aspects, Stage, StageProps, Tags } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { ApiStack } from './ApiStack';
 import { CloudfrontStack } from './CloudfrontStack';
+import { Configurable } from './Configuration';
 import { DNSSECStack } from './DNSSECStack';
 import { DNSStack } from './DNSStack';
 import { KeyStack } from './keystack';
@@ -11,9 +12,7 @@ import { Statics } from './statics';
 import { UsEastCertificateStack } from './UsEastCertificateStack';
 import { WafStack } from './WafStack';
 
-export interface ApiStageProps extends StageProps {
-  branch: string;
-}
+export interface ApiStageProps extends StageProps, Configurable {}
 
 /**
  * Stage responsible for the API Gateway and lambdas
@@ -26,26 +25,27 @@ export class ApiStage extends Stage {
     Tags.of(this).add('Project', Statics.projectName);
     Aspects.of(this).add(new PermissionsBoundaryAspect());
 
+    const branchName = props.configuration.branch;
 
     const keyStack = new KeyStack(this, 'key-stack');
     const sessionsStack = new SessionsStack(this, 'sessions-stack', { key: keyStack.key });
-    const dnsStack = new DNSStack(this, 'dns-stack', { branch: props.branch });
+    const dnsStack = new DNSStack(this, 'dns-stack', { configuration: props.configuration });
 
-    const usEastCertificateStack = new UsEastCertificateStack(this, 'us-cert-stack', { branch: props.branch, env: { region: 'us-east-1' } });
-    const dnssecStack = new DNSSECStack(this, 'dnssec-stack', { branch: props.branch, env: { region: 'us-east-1' }, applicationRegion: this.region! });
+    const usEastCertificateStack = new UsEastCertificateStack(this, 'us-cert-stack', { branch: branchName, env: { region: 'us-east-1' } });
+    const dnssecStack = new DNSSECStack(this, 'dnssec-stack', { branch: branchName, env: { region: 'us-east-1' }, applicationRegion: this.region! });
     usEastCertificateStack.addDependency(dnsStack);
     dnssecStack.addDependency(dnsStack);
 
     const apistack = new ApiStack(this, 'api-stack', {
-      branch: props.branch,
+      branch: branchName,
       sessionsTable: sessionsStack.sessionsTable,
     });
     const cloudfrontStack = new CloudfrontStack(this, 'cloudfront-stack', {
-      branch: props.branch,
+      branch: branchName,
       hostDomain: apistack.domain(),
     });
     cloudfrontStack.addDependency(usEastCertificateStack);
 
-    new WafStack(this, 'waf-stack', { env: { region: 'us-east-1' }, branch: props.branch });
+    new WafStack(this, 'waf-stack', { env: { region: 'us-east-1' }, branch: branchName });
   }
 }

--- a/src/CloudfrontStack.ts
+++ b/src/CloudfrontStack.ts
@@ -62,7 +62,7 @@ export class CloudfrontStack extends Stack {
      * to overkill for us. See: https://repost.aws/knowledge-center/resolve-cnamealreadyexists-error
      * We'll switch manually, sorry.
      */
-    if(props.branch.endsWith('-new-lz')) {
+    if (props.branch.endsWith('-new-lz')) {
       console.warn('Keeping out the nijmegen.nl domain (CloudFront alternative name conflicts workaround)');
     } else {
       domains.push(mainDomain);

--- a/src/CloudfrontStack.ts
+++ b/src/CloudfrontStack.ts
@@ -51,7 +51,20 @@ export class CloudfrontStack extends Stack {
     const cspSubdomain = Statics.cspSubDomain(props.branch);
     const cspDomain = `${cspSubdomain}.csp-nijmegen.nl`;
     const mainDomain = `${subdomain}.nijmegen.nl`;
-    var domains = [mainDomain, cspDomain];
+    var domains = [cspDomain];
+
+    /**
+     * I know this is very ugly, but also very temporarely.
+     * This MUST be removed when the CloudFront domain name is (manually)
+     * switched between the old distribution and the new one.
+     * It is not possible to have two cloudfront distributions listen to
+     * a single alternative domain name... Switching using DNS records is way
+     * to overkill for us. See: https://repost.aws/knowledge-center/resolve-cnamealreadyexists-error
+     * We'll switch manually, sorry.
+     */
+    if (props.branch.endsWith('-new-lz')) {
+      domains.push(mainDomain);
+    }
 
     const certificateArn = this.certificateArn();
 

--- a/src/CloudfrontStack.ts
+++ b/src/CloudfrontStack.ts
@@ -233,6 +233,7 @@ export class CloudfrontStack extends Stack {
       eventBridgeEnabled: true,
       enforceSSL: true,
       encryption: S3.BucketEncryption.S3_MANAGED,
+      objectOwnership: S3.ObjectOwnership.OBJECT_WRITER,
       lifecycleRules: [
         {
           id: 'delete objects after 180 days',

--- a/src/CloudfrontStack.ts
+++ b/src/CloudfrontStack.ts
@@ -62,9 +62,12 @@ export class CloudfrontStack extends Stack {
      * to overkill for us. See: https://repost.aws/knowledge-center/resolve-cnamealreadyexists-error
      * We'll switch manually, sorry.
      */
-    if (props.branch.endsWith('-new-lz')) {
+    if(props.branch.endsWith('-new-lz')) {
+      console.warn('Keeping out the nijmegen.nl domain (CloudFront alternative name conflicts workaround)');
+    } else {
       domains.push(mainDomain);
     }
+
 
     const certificateArn = this.certificateArn();
 

--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -1,0 +1,77 @@
+import { Statics } from './statics';
+
+/**
+ * Adds a configuration field to another interface
+ */
+export interface Configurable {
+  configuration: Configuration;
+}
+
+/**
+ * Environment object (required fields)
+ */
+export interface Environment {
+  account: string;
+  region: string;
+}
+
+/**
+ * Basic configuration options per environment
+ */
+export interface Configuration {
+  /**
+   * Branch name for the applicible branch (this branch)
+   */
+  branch: string;
+
+  /**
+   * Environment to place the pipeline
+   */
+  buildEnvironment: Environment;
+
+  /**
+   * Environment to deploy the application
+   */
+  deploymentEnvironment: Environment;
+
+  /**
+   * CNAME records to deploy in the hosted zone
+   */
+  cnameRecords?: { [key: string]: string };
+
+  /**
+   * A DS record (value) to deploy in the hosted zone
+   */
+  dsRecord?: string;
+}
+
+
+const EnvironmentConfigurations: {[key:string]: Configuration} = {
+  'acceptance-new-lz': {
+    branch: 'acceptance-new-lz',
+    buildEnvironment: Statics.gnBuildEnvironment,
+    deploymentEnvironment: Statics.gnMijnNijmegenAccpEnvironment,
+    cnameRecords: {
+      _554c359f26fbc43f02d85e43dccd6336: '_430b5afffdedea75381eaec545e8189c.vrcmzfbvtx.acm-validations.aws.',
+    },
+    dsRecord: '3766 13 2 11761745E09473E6CE95DB798CF1ADB69B4433E73EEFC9F7FE341561966EA154',
+  },
+  'production-new-lz': {
+    branch: 'production-new-lz',
+
+    buildEnvironment: Statics.gnBuildEnvironment,
+    deploymentEnvironment: Statics.gnMijnNijmegenProdEnvironment,
+    cnameRecords: {
+      _abe87d0d7f8458c5f75c5d1e0bf6efdb: '_0d3e717e52354c47bf6b0c16612b709d.jzckvmdcqj.acm-validations.aws.',
+    },
+    dsRecord: '40951 13 2 1EFF20C0264CD1FDE6C7C858398BC2141768CC014A7BB27997F323076B7C47ED',
+  },
+};
+
+export function getEnvironmentConfiguration(branchName: string) {
+  const conf = EnvironmentConfigurations[branchName];
+  if (!conf) {
+    throw Error(`No configuration found for branch ${branchName}`);
+  }
+  return conf;
+}

--- a/src/DNSStack.ts
+++ b/src/DNSStack.ts
@@ -1,10 +1,10 @@
+import * as crypto from 'crypto';
 import { aws_route53 as Route53, Stack, StackProps, aws_ssm as SSM, Duration } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
+import { Configurable } from './Configuration';
 import { Statics } from './statics';
 
-export interface DNSStackProps extends StackProps {
-  branch: string;
-}
+export interface DNSStackProps extends StackProps, Configurable { }
 
 export class DNSStack extends Stack {
   zone: Route53.HostedZone;
@@ -13,7 +13,7 @@ export class DNSStack extends Stack {
 
   constructor(scope: Construct, id: string, props: DNSStackProps) {
     super(scope, id);
-    this.branch = props.branch;
+    this.branch = props.configuration.branch;
 
     const rootZoneId = SSM.StringParameter.valueForStringParameter(this, Statics.accountRootHostedZoneId);
     const rootZoneName = SSM.StringParameter.valueForStringParameter(this, Statics.accountRootHostedZoneName);
@@ -29,7 +29,8 @@ export class DNSStack extends Stack {
 
     this.addZoneIdAndNametoParams();
     this.addNSToRootCSPzone();
-    this.addDsRecord();
+    this.addDsRecord(props.configuration.dsRecord);
+    this.addCnameRecords(props.configuration.cnameRecords);
 
   }
 
@@ -80,19 +81,7 @@ export class DNSStack extends Stack {
    * Add DS record for the zone to the parent zone
    * to establish a chain of trust (https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-configuring-dnssec-enable-signing.html#dns-configuring-dnssec-chain-of-trust)
    */
-  addDsRecord() {
-    let dsValue = undefined;
-    switch (this.branch) {
-      case 'acceptance':
-        dsValue = '52561 13 2 90CF3C35FDDC30AF42FB4BCCDCCB1123500050D70F1D4886D6DE25502F3BC50A';
-        break;
-      case 'production':
-        dsValue = '60066 13 2 932CD585B029E674E17C4C33DFE7DE2C84353ACD8C109760FD17A6CDBD0CF3FA';
-        break;
-      default:
-        break;
-    }
-
+  addDsRecord(dsValue?: string) {
     if (!dsValue) {
       return; // Skip DS record creation if there is no value.
     }
@@ -102,6 +91,21 @@ export class DNSStack extends Stack {
       recordName: 'mijn',
       values: [dsValue],
       ttl: Duration.seconds(600),
+    });
+  }
+
+  addCnameRecords(cnameRecords?: { [key: string]: string }) {
+    if (!cnameRecords) {
+      return; // No records to define
+    }
+
+    Object.entries(cnameRecords).forEach(record => {
+      const hash = crypto.createHash('md5').update(`${record[0]}${record[1]}`).digest('hex').substring(0, 10);
+      new Route53.CnameRecord(this, `cname-record-${hash}`, {
+        recordName: record[0],
+        domainName: record[1],
+        zone: this.zone,
+      });
     });
   }
 }

--- a/src/DNSStack.ts
+++ b/src/DNSStack.ts
@@ -86,7 +86,7 @@ export class DNSStack extends Stack {
    * to establish a chain of trust (https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-configuring-dnssec-enable-signing.html#dns-configuring-dnssec-chain-of-trust)
    */
   addDsRecord() {
-    let dsValue = '';
+    let dsValue = undefined;
     switch (this.branch) {
       case 'acceptance':
         dsValue = '52561 13 2 90CF3C35FDDC30AF42FB4BCCDCCB1123500050D70F1D4886D6DE25502F3BC50A';
@@ -97,6 +97,11 @@ export class DNSStack extends Stack {
       default:
         break;
     }
+
+    if (!dsValue) {
+      return; // Skip DS record creation if there is no value.
+    }
+
     new Route53.DsRecord(this, 'ds-record', {
       zone: this.accountRootZone,
       recordName: 'mijn',

--- a/src/DNSStack.ts
+++ b/src/DNSStack.ts
@@ -1,4 +1,4 @@
-import { aws_route53 as Route53, Stack, StackProps, aws_ssm as SSM, Duration, CfnOutput } from 'aws-cdk-lib';
+import { aws_route53 as Route53, Stack, StackProps, aws_ssm as SSM, Duration } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { Statics } from './statics';
 
@@ -31,11 +31,6 @@ export class DNSStack extends Stack {
     this.addNSToRootCSPzone();
     this.addDsRecord();
 
-    const compat_output = new CfnOutput(this, 'temp-output', {
-      value: 'Z03105592Z01S4FRBQZQV',
-      exportName: 'mijn-api-dns-stack:ExportsOutputRefmijncspB83B491BB53D10A4',
-    });
-    compat_output.overrideLogicalId('ExportsOutputRefmijncspB83B491BB53D10A4');
   }
 
   /**

--- a/src/ParameterStage.ts
+++ b/src/ParameterStage.ts
@@ -1,4 +1,5 @@
-import { Stack, Tags, Stage, aws_ssm as SSM, aws_secretsmanager as SecretsManager, StageProps } from 'aws-cdk-lib';
+import { PermissionsBoundaryAspect } from '@gemeentenijmegen/aws-constructs';
+import { Stack, Tags, Stage, aws_ssm as SSM, aws_secretsmanager as SecretsManager, StageProps, Aspects } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { Statics } from './statics';
 
@@ -12,6 +13,7 @@ export class ParameterStage extends Stage {
     super(scope, id, props);
     Tags.of(this).add('cdkManaged', 'yes');
     Tags.of(this).add('Project', Statics.projectName);
+    Aspects.of(this).add(new PermissionsBoundaryAspect());
 
     new ParameterStack(this, 'params');
   }

--- a/src/PipelineStack.ts
+++ b/src/PipelineStack.ts
@@ -1,4 +1,5 @@
-import { Stack, StackProps, Tags, pipelines, CfnParameter, Environment } from 'aws-cdk-lib';
+import { PermissionsBoundaryAspect } from '@gemeentenijmegen/aws-constructs';
+import { Stack, StackProps, Tags, pipelines, CfnParameter, Environment, Aspects } from 'aws-cdk-lib';
 import { ShellStep } from 'aws-cdk-lib/pipelines';
 import { Construct } from 'constructs';
 import { ApiStage } from './ApiStage';
@@ -16,6 +17,7 @@ export class PipelineStack extends Stack {
     super(scope, id, props);
     Tags.of(this).add('cdkManaged', 'yes');
     Tags.of(this).add('Project', Statics.projectName);
+    Aspects.of(this).add(new PermissionsBoundaryAspect());
     this.branchName = props.branchName;
 
     const connectionArn = new CfnParameter(this, 'connectionArn');

--- a/src/PipelineStack.ts
+++ b/src/PipelineStack.ts
@@ -68,8 +68,6 @@ export class PipelineStack extends Stack {
 
     const pipeline = new pipelines.CodePipeline(this, `mijnnijmegen-${this.branchName}`, {
       pipelineName: `mijnnijmegen-${this.branchName}`,
-      dockerEnabledForSelfMutation: true,
-      dockerEnabledForSynth: true,
       crossAccountKeys: true,
       synth: synthStep,
     });

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import * as Dotenv from 'dotenv';
 import { PipelineStackAcceptance } from './PipelineStackAcceptance';
 import { PipelineStackDevelopment } from './PipelineStackDevelopment';
 import { PipelineStackProduction } from './PipelineStackProduction';
+import { PipelineStack } from './PipelineStack';
 
 // for development, use sandbox account
 const deploymentEnvironment = {
@@ -25,6 +26,16 @@ const productionEnvironment = {
   region: 'eu-west-1',
 };
 
+const gnBuildEnvironment = {
+  account: '836443378780',
+  region: 'eu-central-1',
+}
+
+const gnMijnNijmegenAccpEnvironment = {
+  account: '836443378780',
+  region: 'eu-central-1',
+}
+
 Dotenv.config();
 const app = new App();
 
@@ -45,12 +56,28 @@ if ('BRANCH_NAME' in process.env == false || process.env.BRANCH_NAME == 'develop
       deployToEnvironment: acceptanceEnvironment,
     },
   );
+} else if (process.env.BRANCH_NAME == 'acceptance-new-lz') {
+  new PipelineStack(app, 'mijnuitkering-pipeline-acceptance-new-lz',
+    {
+      env: gnBuildEnvironment,
+      branchName: 'acceptance-new-lz',
+      deployToEnvironment: gnMijnNijmegenAccpEnvironment,
+    },
+  );
 } else if (process.env.BRANCH_NAME == 'production') {
   new PipelineStackProduction(app, 'mijnuitkering-pipeline-production',
     {
       env: deploymentEnvironment,
       branchName: 'production',
       deployToEnvironment: productionEnvironment,
+    },
+  );
+} else if (process.env.BRANCH_NAME == 'production-new-lz') {
+  new PipelineStack(app, 'mijnuitkering-pipeline-production-new-lz',
+    {
+      env: gnBuildEnvironment,
+      branchName: 'production-new-lz',
+      deployToEnvironment: gnMijnNijmegenAccpEnvironment, // TODO fix this when account is created
     },
   );
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,9 @@
 import { App } from 'aws-cdk-lib';
 import * as Dotenv from 'dotenv';
+import { PipelineStack } from './PipelineStack';
 import { PipelineStackAcceptance } from './PipelineStackAcceptance';
 import { PipelineStackDevelopment } from './PipelineStackDevelopment';
 import { PipelineStackProduction } from './PipelineStackProduction';
-import { PipelineStack } from './PipelineStack';
 
 // for development, use sandbox account
 const deploymentEnvironment = {
@@ -29,12 +29,12 @@ const productionEnvironment = {
 const gnBuildEnvironment = {
   account: '836443378780',
   region: 'eu-central-1',
-}
+};
 
 const gnMijnNijmegenAccpEnvironment = {
   account: '836443378780',
   region: 'eu-central-1',
-}
+};
 
 Dotenv.config();
 const app = new App();

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ import { PipelineStack } from './PipelineStack';
 Dotenv.config();
 const app = new App();
 
-const branchToBuild = process.env.BRANCH_NAME ?? 'development';
+const branchToBuild = process.env.BRANCH_NAME ?? 'acceptance-new-lz';
 const configuration = getEnvironmentConfiguration(branchToBuild);
 
 new PipelineStack(app, `mijnuitkering-pipeline-${configuration.branch}`, {

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,6 +36,11 @@ const gnMijnNijmegenAccpEnvironment = {
   region: 'eu-central-1',
 };
 
+const gnMijnNijmegenProdEnvironment = {
+  account: '740606269759',
+  region: 'eu-central-1',
+};
+
 Dotenv.config();
 const app = new App();
 
@@ -77,7 +82,7 @@ if ('BRANCH_NAME' in process.env == false || process.env.BRANCH_NAME == 'develop
     {
       env: gnBuildEnvironment,
       branchName: 'production-new-lz',
-      deployToEnvironment: gnMijnNijmegenAccpEnvironment, // TODO fix this when account is created
+      deployToEnvironment: gnMijnNijmegenProdEnvironment,
     },
   );
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,90 +1,17 @@
 import { App } from 'aws-cdk-lib';
 import * as Dotenv from 'dotenv';
+import { getEnvironmentConfiguration } from './Configuration';
 import { PipelineStack } from './PipelineStack';
-import { PipelineStackAcceptance } from './PipelineStackAcceptance';
-import { PipelineStackDevelopment } from './PipelineStackDevelopment';
-import { PipelineStackProduction } from './PipelineStackProduction';
-
-// for development, use sandbox account
-const deploymentEnvironment = {
-  account: '418648875085',
-  region: 'eu-west-1',
-};
-
-const sandboxEnvironment = {
-  account: '122467643252',
-  region: 'eu-west-1',
-};
-
-const acceptanceEnvironment = {
-  account: '315037222840',
-  region: 'eu-west-1',
-};
-
-const productionEnvironment = {
-  account: '196212984627',
-  region: 'eu-west-1',
-};
-
-const gnBuildEnvironment = {
-  account: '836443378780',
-  region: 'eu-central-1',
-};
-
-const gnMijnNijmegenAccpEnvironment = {
-  account: '021929636313',
-  region: 'eu-central-1',
-};
-
-const gnMijnNijmegenProdEnvironment = {
-  account: '740606269759',
-  region: 'eu-central-1',
-};
 
 Dotenv.config();
 const app = new App();
 
+const branchToBuild = process.env.BRANCH_NAME ?? 'development';
+const configuration = getEnvironmentConfiguration(branchToBuild);
 
-if ('BRANCH_NAME' in process.env == false || process.env.BRANCH_NAME == 'development') {
-  new PipelineStackDevelopment(app, 'mijnuitkering-pipeline-development',
-    {
-      env: deploymentEnvironment,
-      branchName: 'development',
-      deployToEnvironment: sandboxEnvironment,
-    },
-  );
-} else if (process.env.BRANCH_NAME == 'acceptance') {
-  new PipelineStackAcceptance(app, 'mijnuitkering-pipeline-acceptance',
-    {
-      env: deploymentEnvironment,
-      branchName: 'acceptance',
-      deployToEnvironment: acceptanceEnvironment,
-    },
-  );
-} else if (process.env.BRANCH_NAME == 'acceptance-new-lz') {
-  new PipelineStack(app, 'mijnuitkering-pipeline-acceptance-new-lz',
-    {
-      env: gnBuildEnvironment,
-      branchName: 'acceptance-new-lz',
-      deployToEnvironment: gnMijnNijmegenAccpEnvironment,
-    },
-  );
-} else if (process.env.BRANCH_NAME == 'production') {
-  new PipelineStackProduction(app, 'mijnuitkering-pipeline-production',
-    {
-      env: deploymentEnvironment,
-      branchName: 'production',
-      deployToEnvironment: productionEnvironment,
-    },
-  );
-} else if (process.env.BRANCH_NAME == 'production-new-lz') {
-  new PipelineStack(app, 'mijnuitkering-pipeline-production-new-lz',
-    {
-      env: gnBuildEnvironment,
-      branchName: 'production-new-lz',
-      deployToEnvironment: gnMijnNijmegenProdEnvironment,
-    },
-  );
-}
+new PipelineStack(app, `mijnuitkering-pipeline-${configuration.branch}`, {
+  env: configuration.buildEnvironment,
+  configuration: configuration,
+});
 
 app.synth();

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,7 +32,7 @@ const gnBuildEnvironment = {
 };
 
 const gnMijnNijmegenAccpEnvironment = {
-  account: '836443378780',
+  account: '021929636313',
   region: 'eu-central-1',
 };
 

--- a/src/statics.ts
+++ b/src/statics.ts
@@ -117,6 +117,8 @@ export abstract class Statics {
     const subdomainMap = {
       acceptance: 'mijn.accp',
       production: 'mijn',
+      'acceptance-new-lz': 'mijn.accp',
+      'production-new-lz': 'mijn',
     };
     const subdomain = subdomainMap[branch as keyof typeof subdomainMap] ?? 'mijn-dev';
     return subdomain;
@@ -126,6 +128,8 @@ export abstract class Statics {
     const subdomainMap = {
       acceptance: 'mijn.accp',
       production: 'mijn.auth-prod',
+      'acceptance-new-lz': 'mijn.mijn-accp',
+      'production-new-lz': 'mijn.mijn-prod',
     };
     const subdomain = subdomainMap[branch as keyof typeof subdomainMap] ?? 'mijn-dev';
     return subdomain;

--- a/src/statics.ts
+++ b/src/statics.ts
@@ -113,6 +113,43 @@ export abstract class Statics {
   static readonly ssmSlackWebhookUrl: string = '/cdk/mijn-nijmegen/slack-webhook-url';
 
 
+  // ENVIRONMENTS
+
+  static readonly deploymentEnvironment = {
+    account: '418648875085',
+    region: 'eu-west-1',
+  };
+
+  static readonly sandboxEnvironment = {
+    account: '122467643252',
+    region: 'eu-west-1',
+  };
+
+  static readonly acceptanceEnvironment = {
+    account: '315037222840',
+    region: 'eu-west-1',
+  };
+
+  static readonly productionEnvironment = {
+    account: '196212984627',
+    region: 'eu-west-1',
+  };
+
+  static readonly gnBuildEnvironment = {
+    account: '836443378780',
+    region: 'eu-central-1',
+  };
+
+  static readonly gnMijnNijmegenAccpEnvironment = {
+    account: '021929636313',
+    region: 'eu-central-1',
+  };
+
+  static readonly gnMijnNijmegenProdEnvironment = {
+    account: '740606269759',
+    region: 'eu-central-1',
+  };
+
   static subDomain(branch: string) {
     const subdomainMap = {
       'acceptance': 'mijn.accp',

--- a/src/statics.ts
+++ b/src/statics.ts
@@ -115,8 +115,8 @@ export abstract class Statics {
 
   static subDomain(branch: string) {
     const subdomainMap = {
-      acceptance: 'mijn.accp',
-      production: 'mijn',
+      'acceptance': 'mijn.accp',
+      'production': 'mijn',
       'acceptance-new-lz': 'mijn.accp',
       'production-new-lz': 'mijn',
     };
@@ -126,8 +126,8 @@ export abstract class Statics {
 
   static cspSubDomain(branch: string) {
     const subdomainMap = {
-      acceptance: 'mijn.accp',
-      production: 'mijn.auth-prod',
+      'acceptance': 'mijn.accp',
+      'production': 'mijn.auth-prod',
       'acceptance-new-lz': 'mijn.mijn-accp',
       'production-new-lz': 'mijn.mijn-prod',
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1395,6 +1395,11 @@
   dependencies:
     "@types/aws-lambda" "^8.10.119"
 
+"@gemeentenijmegen/aws-constructs@^0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@gemeentenijmegen/aws-constructs/-/aws-constructs-0.0.4.tgz#ea4440bfd02f660643ffdbed98867559805369f4"
+  integrity sha512-POfKPHohkk6PQBM5KE4gqks+y4jnNKbitt+pQ4yi+y0fbKgWOj5kRdD3eQKSdDDqqrQx2+lVJah58rLJDAA6LQ==
+
 "@gemeentenijmegen/projen-project-type@^1.5.2":
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@gemeentenijmegen/projen-project-type/-/projen-project-type-1.5.2.tgz#703f4eac3fb5cd8da1ef61a9389bbb4d850a0bb5"


### PR DESCRIPTION
- Add config object
- Add configurable interface
- Simplify main file
- Use config object in pipeline stack, api stage and dns stack.
- Update tests

Warning 🚨: this introduces more differences between the old lz and new lz. In addition to the existing changes to prepare for the new lz. 