### PR TITLE
feat: Remove digid notice

### DIFF
--- a/src/app/login/templates/login-yivi.mustache
+++ b/src/app/login/templates/login-yivi.mustache
@@ -10,9 +10,6 @@
                 <a href="{{{authUrlDigid}}}" class="btn btn-primary waves-effect waves-light display-table btn-digid">
                     <span class="title"> Inloggen </span><span class="assistive">met DigiD</span>
                 </a>
-                <div class="info">
-                    <svg class="mdi mdi-information" aria-hidden="true" viewBox="0 0 24 24" width="24" height="24" xmlns="http://www.w3.org/2000/svg"><path d="m13 9h-2v-2h2m0 10h-2v-6h2m-1-9a10 10 0 0 0 -10 10 10 10 0 0 0 10 10 10 10 0 0 0 10-10 10 10 0 0 0 -10-10z"/></svg>Vanaf <strong>1 augustus</strong> kunt u inloggen met de DigiD-app of met uw gebruikersnaam en wachtwoord, met een bevestiging via SMS. U kunt dan niet meer inloggen met alleen uw gebruikersnaam en wachtwoord.
-                </div>
             </div>
             <div>
                 <a href="{{{authUrlYivi}}}" class="btn btn-primary waves-effect waves-light display-table btn-yivi">


### PR DESCRIPTION
The digid minimum authlevel has been changed to 'midden', so the notice is no longer necessary.

Fixes #471 