### PR TITLE
chore: Cleanup LZ-dependent code

### DIFF
--- a/src/ApiStage.ts
+++ b/src/ApiStage.ts
@@ -23,9 +23,7 @@ export class ApiStage extends Stage {
 
     Tags.of(this).add('cdkManaged', 'yes');
     Tags.of(this).add('Project', Statics.projectName);
-    if (props.configuration.envIsInNewLandingZone) {
-      Aspects.of(this).add(new PermissionsBoundaryAspect());
-    }
+    Aspects.of(this).add(new PermissionsBoundaryAspect());
 
     const branchName = props.configuration.branch;
 

--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -45,12 +45,6 @@ export interface Configuration {
   dsRecord?: string;
 
   /**
-   * Boolean to indicate if the environment to deploy to is in
-   * the new landingzone. (for including permissionboundaryaspect or other stuff)
-   */
-  envIsInNewLandingZone: boolean;
-
-  /**
    * The CDK name of the pipeline stack (can be removed after
    * moving to new lz)
    */
@@ -68,7 +62,6 @@ const EnvironmentConfigurations: {[key:string]: Configuration} = {
       _554c359f26fbc43f02d85e43dccd6336: '_430b5afffdedea75381eaec545e8189c.vrcmzfbvtx.acm-validations.aws.',
     },
     dsRecord: '3766 13 2 11761745E09473E6CE95DB798CF1ADB69B4433E73EEFC9F7FE341561966EA154',
-    envIsInNewLandingZone: true,
     pipelineStackCdkName: 'mijnnijmegen-pipeline-acceptance',
     pipelineName: 'mijnnijmegen-acceptance',
   },
@@ -80,7 +73,6 @@ const EnvironmentConfigurations: {[key:string]: Configuration} = {
       _abe87d0d7f8458c5f75c5d1e0bf6efdb: '_0d3e717e52354c47bf6b0c16612b709d.jzckvmdcqj.acm-validations.aws.',
     },
     dsRecord: '40951 13 2 1EFF20C0264CD1FDE6C7C858398BC2141768CC014A7BB27997F323076B7C47ED',
-    envIsInNewLandingZone: true,
     pipelineStackCdkName: 'mijnnijmegen-pipeline-production',
     pipelineName: 'mijnnijmegen-production',
   },
@@ -92,7 +84,6 @@ const EnvironmentConfigurations: {[key:string]: Configuration} = {
       _554c359f26fbc43f02d85e43dccd6336: '_430b5afffdedea75381eaec545e8189c.vrcmzfbvtx.acm-validations.aws.',
     },
     dsRecord: '3766 13 2 11761745E09473E6CE95DB798CF1ADB69B4433E73EEFC9F7FE341561966EA154',
-    envIsInNewLandingZone: true,
     pipelineStackCdkName: 'mijnnijmegen-pipeline-acceptance',
     pipelineName: 'mijnnijmegen-acceptance',
   },
@@ -104,7 +95,6 @@ const EnvironmentConfigurations: {[key:string]: Configuration} = {
       _abe87d0d7f8458c5f75c5d1e0bf6efdb: '_0d3e717e52354c47bf6b0c16612b709d.jzckvmdcqj.acm-validations.aws.',
     },
     dsRecord: '40951 13 2 1EFF20C0264CD1FDE6C7C858398BC2141768CC014A7BB27997F323076B7C47ED',
-    envIsInNewLandingZone: true,
     pipelineStackCdkName: 'mijnnijmegen-pipeline-production',
     pipelineName: 'mijnnijmegen-production',
   },

--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -76,28 +76,6 @@ const EnvironmentConfigurations: {[key:string]: Configuration} = {
     pipelineStackCdkName: 'mijnnijmegen-pipeline-production',
     pipelineName: 'mijnnijmegen-production',
   },
-  'acceptance-new-lz': {
-    branch: 'acceptance',
-    buildEnvironment: Statics.gnBuildEnvironment,
-    deploymentEnvironment: Statics.gnMijnNijmegenAccpEnvironment,
-    cnameRecords: {
-      _554c359f26fbc43f02d85e43dccd6336: '_430b5afffdedea75381eaec545e8189c.vrcmzfbvtx.acm-validations.aws.',
-    },
-    dsRecord: '3766 13 2 11761745E09473E6CE95DB798CF1ADB69B4433E73EEFC9F7FE341561966EA154',
-    pipelineStackCdkName: 'mijnnijmegen-pipeline-acceptance',
-    pipelineName: 'mijnnijmegen-acceptance',
-  },
-  'production-new-lz': {
-    branch: 'production',
-    buildEnvironment: Statics.gnBuildEnvironment,
-    deploymentEnvironment: Statics.gnMijnNijmegenProdEnvironment,
-    cnameRecords: {
-      _abe87d0d7f8458c5f75c5d1e0bf6efdb: '_0d3e717e52354c47bf6b0c16612b709d.jzckvmdcqj.acm-validations.aws.',
-    },
-    dsRecord: '40951 13 2 1EFF20C0264CD1FDE6C7C858398BC2141768CC014A7BB27997F323076B7C47ED',
-    pipelineStackCdkName: 'mijnnijmegen-pipeline-production',
-    pipelineName: 'mijnnijmegen-production',
-  },
 };
 
 export function getEnvironmentConfiguration(branchName: string) {

--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -54,7 +54,7 @@ export interface Configuration {
 
 
 const EnvironmentConfigurations: {[key:string]: Configuration} = {
-  'acceptance': {
+  acceptance: {
     branch: 'acceptance',
     buildEnvironment: Statics.gnBuildEnvironment,
     deploymentEnvironment: Statics.gnMijnNijmegenAccpEnvironment,
@@ -65,7 +65,7 @@ const EnvironmentConfigurations: {[key:string]: Configuration} = {
     pipelineStackCdkName: 'mijnnijmegen-pipeline-acceptance',
     pipelineName: 'mijnnijmegen-acceptance',
   },
-  'production': {
+  production: {
     branch: 'production',
     buildEnvironment: Statics.gnBuildEnvironment,
     deploymentEnvironment: Statics.gnMijnNijmegenProdEnvironment,

--- a/src/DNSSECStack.ts
+++ b/src/DNSSECStack.ts
@@ -40,31 +40,14 @@ export class DNSSECStack extends Stack {
       hostedZoneId: zoneId,
     });
 
-    /**
-     * New ksk in prod only
-     */
-    if (props.branch === 'production') {
-      // Production KSK
-      const accountKmsKeyArnForDnsSec = SSM.StringParameter.valueForStringParameter(this, Statics.ssmAccountDnsSecKmsKey);
-      const dnssecKeySigningNew = new Route53.CfnKeySigningKey(this, 'dnssec-keysigning-key', {
-        name: 'mijn_nijmegen_key_signing_key',
-        status: 'ACTIVE',
-        hostedZoneId: zoneId,
-        keyManagementServiceArn: accountKmsKeyArnForDnsSec,
-      });
-      dnssec.node.addDependency(dnssecKeySigningNew);
-    } else {
-      // Acceptance KSK
-      const accountDnssecKmsKeyArn = SSM.StringParameter.valueForStringParameter(this, Statics.ssmAccountDnsSecKmsKey);
-      const dnssecKeySigning = new Route53.CfnKeySigningKey(this, 'dnssec-keysigning-key-2', {
-        name: 'mijn_nijmegen_ksk',
-        status: 'ACTIVE',
-        hostedZoneId: zoneId,
-        keyManagementServiceArn: accountDnssecKmsKeyArn,
-      });
-      dnssec.node.addDependency(dnssecKeySigning);
-    }
-
+    const accountDnssecKmsKeyArn = SSM.StringParameter.valueForStringParameter(this, Statics.ssmAccountDnsSecKmsKey);
+    const dnssecKeySigning = new Route53.CfnKeySigningKey(this, 'dnssec-keysigning-key-2', {
+      name: 'mijn_nijmegen_ksk',
+      status: 'ACTIVE',
+      hostedZoneId: zoneId,
+      keyManagementServiceArn: accountDnssecKmsKeyArn,
+    });
+    dnssec.node.addDependency(dnssecKeySigning);
 
   }
 

--- a/src/ParameterStage.ts
+++ b/src/ParameterStage.ts
@@ -15,9 +15,7 @@ export class ParameterStage extends Stage {
     super(scope, id, props);
     Tags.of(this).add('cdkManaged', 'yes');
     Tags.of(this).add('Project', Statics.projectName);
-    if (props.configuration.envIsInNewLandingZone) {
-      Aspects.of(this).add(new PermissionsBoundaryAspect());
-    }
+    Aspects.of(this).add(new PermissionsBoundaryAspect());
 
     new ParameterStack(this, 'params');
   }

--- a/src/PipelineStack.ts
+++ b/src/PipelineStack.ts
@@ -15,9 +15,7 @@ export class PipelineStack extends Stack {
     super(scope, id, props);
     Tags.of(this).add('cdkManaged', 'yes');
     Tags.of(this).add('Project', Statics.projectName);
-    if (props.configuration.envIsInNewLandingZone) {
-      Aspects.of(this).add(new PermissionsBoundaryAspect());
-    }
+    Aspects.of(this).add(new PermissionsBoundaryAspect());
     this.branchName = props.configuration.branch;
 
     const connectionArn = new CfnParameter(this, 'connectionArn');

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -22,7 +22,6 @@ const config: Configuration = {
     '_1241251': '120421305.csp-nijmegen.nl',
   },
   dsRecord: undefined,
-  envIsInNewLandingZone: true,
   pipelineStackCdkName: 'mijnnijmegen-pipeline-stack-testing',
   pipelineName: 'mijnnijmegen-test'
 }


### PR DESCRIPTION
Since we only run this in the new LZ, the lz-dependent code can be removed.