### PR TITLE
feat: Move nav update to constructor of home

### DIFF
--- a/src/app/home/home.lambda.ts
+++ b/src/app/home/home.lambda.ts
@@ -1,9 +1,10 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { ApiGatewayV2Response, Response } from '@gemeentenijmegen/apigateway-http/lib/V2/Response';
 import { APIGatewayProxyEventV2 } from 'aws-lambda';
-import { homeRequestHandler } from './homeRequestHandler';
+import { HomeRequestHandler } from './homeRequestHandler';
 
 const dynamoDBClient = new DynamoDBClient({});
+const requestHandler = new HomeRequestHandler(dynamoDBClient, { showZaken: process.env.SHOW_ZAKEN == 'True' });
 
 function parseEvent(event: APIGatewayProxyEventV2) {
   return {
@@ -14,7 +15,7 @@ function parseEvent(event: APIGatewayProxyEventV2) {
 export async function handler (event: any, _context: any):Promise<ApiGatewayV2Response> {
   try {
     const params = parseEvent(event);
-    return await homeRequestHandler(params.cookies, dynamoDBClient, { showZaken: process.env.SHOWZAKEN == 'True' });
+    return await requestHandler.handleRequest(params.cookies);
 
   } catch (err) {
     console.error(err);

--- a/src/app/home/tests/home.test.ts
+++ b/src/app/home/tests/home.test.ts
@@ -2,7 +2,7 @@ import { writeFile } from 'fs';
 import path from 'path';
 import { DynamoDBClient, GetItemCommand, GetItemCommandOutput } from '@aws-sdk/client-dynamodb';
 import { mockClient } from 'aws-sdk-client-mock';
-import { homeRequestHandler } from '../homeRequestHandler';
+import { HomeRequestHandler } from '../homeRequestHandler';
 
 beforeAll(() => {
 
@@ -38,7 +38,8 @@ beforeEach(() => {
 
 test('Returns 200', async () => {
   const dynamoDBClient = new DynamoDBClient({ region: 'eu-west-1' });
-  const result = await homeRequestHandler('session=12345', dynamoDBClient);
+  const handler = new HomeRequestHandler(dynamoDBClient, { showZaken: false });
+  const result = await handler.handleRequest('session=12345');
 
   expect(result.statusCode).toBe(200);
   let cookies = result?.cookies?.filter((cookie: string) => cookie.indexOf('HttpOnly; Secure'));
@@ -47,7 +48,8 @@ test('Returns 200', async () => {
 
 test('Shows overview page', async () => {
   const dynamoDBClient = new DynamoDBClient({ region: 'eu-west-1' });
-  const result = await homeRequestHandler('session=12345', dynamoDBClient, { showZaken: false });
+  const handler = new HomeRequestHandler(dynamoDBClient, { showZaken: false });
+  const result = await handler.handleRequest('session=12345');
   expect(result.body).toMatch('Mijn Nijmegen');
   expect(result.body).toMatch('Jan de Tester');
   writeFile(path.join(__dirname, 'output', 'test2.html'), result.body ?? '', () => { });


### PR DESCRIPTION
Since the nav was appended to on each request, adding zaken resulted in many header-updates.

This moves the homerequesthandler to be a class, which is instantiated once, and updates the nav in the constructor. Calling `handler.handleRequest` now actually handles a new request.