### PR TITLE
feat: Alway show zaken

### DIFF
--- a/src/ApiFunction.ts
+++ b/src/ApiFunction.ts
@@ -41,6 +41,7 @@ export class ApiFunction extends Construct {
         OIDC_CLIENT_ID: SSM.StringParameter.valueForStringParameter(this, Statics.ssmOIDCClientID),
         OIDC_SCOPE: SSM.StringParameter.valueForStringParameter(this, Statics.ssmOIDCScope),
         SESSION_TABLE: props.table.tableName,
+        SHOW_ZAKEN: 'True',
         ...props.environment,
       },
     });


### PR DESCRIPTION
Add env variable for SHOW_ZAKEN to prevent var
being removed by AWS. Set to True, since we're
live. Flag hasn't been removed yet to allow quick
changes should there be issues with the
functionality.