### PR TITLE
feat: Add option to override lambda props

### DIFF
--- a/src/ApiFunction.ts
+++ b/src/ApiFunction.ts
@@ -1,6 +1,7 @@
 import { aws_lambda as Lambda, aws_dynamodb, aws_ssm as SSM, RemovalPolicy, Duration, Stack } from 'aws-cdk-lib';
 import { Alarm } from 'aws-cdk-lib/aws-cloudwatch';
 import { Role } from 'aws-cdk-lib/aws-iam';
+import { FunctionProps } from 'aws-cdk-lib/aws-lambda';
 import { FilterPattern, IFilterPattern, MetricFilter, RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Construct } from 'constructs';
 import { LambdaReadOnlyPolicy } from './iam/lambda-readonly-policy';
@@ -18,6 +19,11 @@ export interface ApiFunctionProps {
   environment?: {[key: string]: string};
   monitorFilterPattern?: IFilterPattern;
   readOnlyRole: Role;
+  /**
+   * The default 'Lambda Function' props can be overridden or amended using
+   * properties provided in this property. These will map to the props of the lambda
+   */
+  functionProps?: Partial<FunctionProps>;
 }
 
 export class ApiFunction extends Construct {
@@ -44,6 +50,7 @@ export class ApiFunction extends Construct {
         SHOW_ZAKEN: 'True',
         ...props.environment,
       },
+      ...props.functionProps,
     });
     props.table.grantReadWriteData(this.lambda.grantPrincipal);
 

--- a/src/ApiStack.ts
+++ b/src/ApiStack.ts
@@ -1,6 +1,6 @@
 import * as apigatewayv2 from '@aws-cdk/aws-apigatewayv2-alpha';
 import { HttpLambdaIntegration } from '@aws-cdk/aws-apigatewayv2-integrations-alpha';
-import { aws_secretsmanager, Stack, StackProps } from 'aws-cdk-lib';
+import { aws_secretsmanager, Duration, Stack, StackProps } from 'aws-cdk-lib';
 import { Table } from 'aws-cdk-lib/aws-dynamodb';
 import { AccountPrincipal, PrincipalWithConditions, Role } from 'aws-cdk-lib/aws-iam';
 import { ISecret, Secret } from 'aws-cdk-lib/aws-secretsmanager';
@@ -311,6 +311,10 @@ export class ApiStack extends Stack implements Configurable {
       },
       readOnlyRole,
       apiFunction: ZakenFunction,
+      functionProps: {
+        timeout: Duration.seconds(15),
+        memorySize: 1024,
+      },
     });
     jwtSecret.grantRead(zakenFunction.lambda);
     tokenSecret.grantRead(zakenFunction.lambda);


### PR DESCRIPTION
We need to set a higher timeout + memory limit for the zaken-function. This commit allows for setting and overriding function properties on the lambda.