### PR TITLE
fix: accessibility issues

### DIFF
--- a/src/app/static-resources/static/styles/screen.css
+++ b/src/app/static-resources/static/styles/screen.css
@@ -259,7 +259,7 @@ nav.nijmegen-sidenav li svg {
     outline: #323232;
     fill: none;
 }
-
+ 
 nav.nijmegen-sidenav a, 
 nav.nijmegen-sidenav a:visited {
     text-decoration: none;
@@ -268,7 +268,8 @@ nav.nijmegen-sidenav a:visited {
     flex-grow: 1;
 }
 
-nav.nijmegen-sidenav a:hover {
+nav.nijmegen-sidenav a:hover, 
+.navbar-nav .nav-item a:hover {
     text-decoration: underline;
 }
 

--- a/src/shared/header.mustache
+++ b/src/shared/header.mustache
@@ -64,7 +64,7 @@
             <span class="navbar-toggler-icon" aria-hidden="true"></span>
         </button>
         <a class="navbar-brand" href="/">
-            <span class="sr-only">Hoofdpagina</span>
+            <span class="sr-only">Homepage Mijn Nijmegen</span>
             <div class="navbar-brand-container">
                 <img src="https://componenten.nijmegen.nl/v6.3.2/img/beeldmerklabel.svg" class="logo-labeled" alt="Logo Nijmegen">
                 <img src="https://componenten.nijmegen.nl/v6.3.2/img/beeldmerk.svg" class="logo" aria-hidden="true" alt="Logo Nijmegen">
@@ -74,13 +74,13 @@
         <div class="collapse navbar-collapse" id="navbar-collapse">
             <ul class="navbar-nav ml-auto">
                 <li class="nav-item">
-                    <a class="nav-link nav-no-link" href="/logout">{{volledigenaam}}
-                        <svg title="Uitloggen" xmlns="http://www.w3.org/2000/svg"  width="16"  height="16"  viewBox="0 0 24 24"  fill="none"  stroke="currentColor"  stroke-width="2"  stroke-linecap="round"  stroke-linejoin="round"  class="icon"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M14 8v-2a2 2 0 0 0 -2 -2h-7a2 2 0 0 0 -2 2v12a2 2 0 0 0 2 2h7a2 2 0 0 0 2 -2v-2" /><path d="M9 12h12l-3 -3" /><path d="M18 15l3 -3" /></svg>
+                    <a class="nav-link nav-no-link" href="/logout" title="Uitloggen">{{volledigenaam}}
+                        <svg title="Uitloggen" xmlns="http://www.w3.org/2000/svg"  width="16"  height="16"  viewBox="0 0 24 24"  fill="none"  stroke="currentColor"  stroke-width="2"  stroke-linecap="round"  stroke-linejoin="round"  class="icon aria-hidden"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M14 8v-2a2 2 0 0 0 -2 -2h-7a2 2 0 0 0 -2 2v12a2 2 0 0 0 2 2h7a2 2 0 0 0 2 -2v-2" /><path d="M9 12h12l-3 -3" /><path d="M18 15l3 -3" /></svg>
                     </a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link nav-no-link" href="https://nijmegen.nl">Nijmegen.nl
-                        <svg  xmlns="http://www.w3.org/2000/svg"  width="16"  height="16"  viewBox="0 0 24 24"  fill="none"  stroke="currentColor"  stroke-width="2"  stroke-linecap="round"  stroke-linejoin="round"  class="icon-link"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M12 6h-6a2 2 0 0 0 -2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2 -2v-6" /><path d="M11 13l9 -9" /><path d="M15 4h5v5" /></svg>
+                        <svg  xmlns="http://www.w3.org/2000/svg"  width="16"  height="16"  viewBox="0 0 24 24"  fill="none" stroke="currentColor"  stroke-width="2"  stroke-linecap="round"  stroke-linejoin="round"  class="icon-link aria-hidden"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M12 6h-6a2 2 0 0 0 -2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2 -2v-6" /><path d="M11 13l9 -9" /><path d="M15 4h5v5" /></svg>
                     </a>
                 </li>
             </ul>


### PR DESCRIPTION
Fixes #1058: 
- The Logo link was not concrete on where it
linked. Changes the screenreader text from 'Hoofdpagina' to 'Homepage
Mijn Nijmegen'.
- Hide icons in header (logout / nijmegen.nl link) from accessibility
tools.
  - Logout is not explicitly added to the title 'Uitloggen', since the
    only hint this was a logout link was the icon.
  - The other icon has no real content value, since the link text being
    'nijmegen.nl' already fully explains where the link will lead.

Fixes #1059:
Underline links in header, when
hovered, to show the link is a link, and it's under the cursor.