### PR TITLE
feat: add survey cta

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       pull-requests: write
       contents: write
-    if: contains(github.event.pull_request.labels.*.name, 'auto-merge') && (github.base_ref == 'acceptance')
+    if: contains(github.event.pull_request.labels.*.name, 'auto-merge') && github.base_ref == 'acceptance'
     steps:
       - env:
           PR_URL: ${{github.event.pull_request.html_url}}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       pull-requests: write
       contents: write
-    if: contains(github.event.pull_request.labels.*.name, 'auto-merge') && github.base_ref == 'acceptance'
+    if: contains(github.event.pull_request.labels.*.name, 'auto-merge') && (github.base_ref == 'acceptance')
     steps:
       - env:
           PR_URL: ${{github.event.pull_request.html_url}}

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -73,6 +73,11 @@ const project = new GemeenteNijmegenCdkApp({
     'test/playwright/report',
     'test/playwright/screenshots',
   ],
+  tsconfig: {
+    compilerOptions: {
+      lib: ['es2021'],
+    },
+  },
 });
 
 

--- a/src/ApiStack.ts
+++ b/src/ApiStack.ts
@@ -178,6 +178,9 @@ export class ApiStack extends Stack implements Configurable {
       applicationUrlBase: baseUrl,
       readOnlyRole,
       apiFunction: LogoutFunction,
+      environment: {
+        SHOW_SURVEY: this.configuration.showSurveyCTA ? 'true' : 'false',
+      },
     });
   }
 
@@ -260,6 +263,7 @@ export class ApiStack extends Stack implements Configurable {
         MTLS_CLIENT_CERT_NAME: mtlsConfig.clientCert.parameterName,
         MTLS_ROOT_CA_NAME: mtlsConfig.rootCert.parameterName,
         BRP_API_URL: StringParameter.valueForStringParameter(this, Statics.ssmBrpApiEndpointUrl),
+        SHOW_SURVEY: this.configuration.showSurveyCTA ? 'true' : 'false',
       },
       apiFunction: PersoonsgegevensFunction,
     });
@@ -283,6 +287,7 @@ export class ApiStack extends Stack implements Configurable {
         MTLS_ROOT_CA_NAME: mtlsConfig.rootCert.parameterName,
         BRP_API_URL: StringParameter.valueForStringParameter(this, Statics.ssmBrpApiEndpointUrl),
         UITKERING_API_URL: StringParameter.valueForStringParameter(this, Statics.ssmUitkeringsApiEndpointUrl),
+        SHOW_SURVEY: this.configuration.showSurveyCTA ? 'true' : 'false',
       },
       apiFunction: UitkeringFunction,
     });
@@ -315,6 +320,7 @@ export class ApiStack extends Stack implements Configurable {
         USE_TAKEN: this.configuration.zakenUseTaken ? 'true' : 'false',
         SUBMISSIONS_LIVE: this.configuration.zakenUseSubmissions ? 'true' : 'false',
         ALLOWED_ZAKEN_DOMAINS: this.configuration.zakenAllowDomains.join(','),
+        SHOW_SURVEY: this.configuration.showSurveyCTA ? 'true' : 'false',
       },
       readOnlyRole,
       apiFunction: ZakenFunction,

--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -71,6 +71,12 @@ export interface Configuration {
   readonly zakenIsLive?: boolean;
 
   /**
+   * Feature flag: if this is falsey, the lambda will
+   * not show the survey CTA.
+   */
+  readonly showSurveyCTA?: boolean;
+
+  /**
    * Feature flag: The taken functionality is experimental
    * If this flag is not true, the taken-functionality will
    * always exit immediately.
@@ -109,6 +115,7 @@ const EnvironmentConfigurations: {[key:string]: Configuration} = {
     zakenIsLive: true,
     zakenUseSubmissions: true,
     zakenAllowDomains: ['APV', 'JZ'],
+    showSurveyCTA: true,
   },
   production: {
     branch: 'production',

--- a/src/app/logout/handleLogoutRequest.ts
+++ b/src/app/logout/handleLogoutRequest.ts
@@ -4,6 +4,7 @@ import { Session } from '@gemeentenijmegen/session';
 import cookie from 'cookie';
 import * as logoutTemplate from './templates/logout.mustache';
 import { render } from '../../shared/render';
+import * as surveyCTA from '../../shared/survey-cta.mustache';
 
 export async function handleLogoutRequest(cookies: string, dynamoDBClient: DynamoDBClient) {
   let session = new Session(cookies, dynamoDBClient);
@@ -13,7 +14,9 @@ export async function handleLogoutRequest(cookies: string, dynamoDBClient: Dynam
     });
   }
 
-  const html = await render({ title: 'Uitgelogd' }, logoutTemplate.default);
+  const html = await render({ title: 'Uitgelogd' }, logoutTemplate.default, {
+    surveyCTA: process.env.SHOW_SURVEY == 'true' ? surveyCTA.default : undefined,
+  });
   const emptyCookie = cookie.serialize('session', '', {
     httpOnly: true,
     secure: true,

--- a/src/app/logout/templates/logout.mustache
+++ b/src/app/logout/templates/logout.mustache
@@ -5,6 +5,7 @@
     <div class="container" id="section-1">
             <h1>Uitgelogd</h1>
             <p class="lead">U bent nu uitgelogd.</p>
+            {{> surveyCTA }}
         </div>
     </div>
 

--- a/src/app/persoonsgegevens/persoonsgegevensRequestHandler.ts
+++ b/src/app/persoonsgegevens/persoonsgegevensRequestHandler.ts
@@ -7,6 +7,7 @@ import { BrpApi } from './BrpApi';
 import * as template from './templates/persoonsgegevens.mustache';
 import { Navigation } from '../../shared/Navigation';
 import { render } from '../../shared/render';
+import * as surveyCTA from '../../shared/survey-cta.mustache';
 
 interface Config {
   apiClient: ApiClient;
@@ -60,9 +61,9 @@ export class PersoonsgegevensRequestHandler {
     data.shownav = true;
     data.nav = navigation.items;
     // render page
-    const html = await render(data, template.default);
+    const html = await render(data, template.default, {
+      surveyCTA: process.env.SHOW_SURVEY == 'true' ? surveyCTA.default : undefined,
+    });
     return Response.html(html, 200, session.getCookie());
   }
-
 }
-

--- a/src/app/persoonsgegevens/templates/persoonsgegevens.mustache
+++ b/src/app/persoonsgegevens/templates/persoonsgegevens.mustache
@@ -97,6 +97,7 @@
                 <h2>Er is iets misgegaan</h2>
                 <p>{{error}}</p>
                 {{/error}}
+                {{> surveyCTA }}
             </div>
         </div>
     </div>

--- a/src/app/static-resources/static/styles/screen.css
+++ b/src/app/static-resources/static/styles/screen.css
@@ -285,3 +285,14 @@ nav.nijmegen-sidenav li.active svg {
     outline: #157C68;
     stroke: #157C68;
 }
+
+.cta {
+    display: flex;
+    align-items: center;
+    gap: .5rem;
+}
+
+.cta a.btn {
+    width: auto;
+    flex-shrink: 0;
+}

--- a/src/app/uitkeringen/templates/uitkeringen.mustache
+++ b/src/app/uitkeringen/templates/uitkeringen.mustache
@@ -50,6 +50,7 @@
                     <h2>Er is iets misgegaan</h2>
                     <p>{{error}}</p>
                 {{/error}}
+            {{> surveyCTA }}
             </div>
         </div>
     </div>

--- a/src/app/uitkeringen/tests/uitkering.test.ts
+++ b/src/app/uitkeringen/tests/uitkering.test.ts
@@ -22,6 +22,8 @@ beforeAll(() => {
   process.env.CLIENT_SECRET_ARN = '123';
   process.env.OIDC_CLIENT_ID = '1234';
   process.env.OIDC_SCOPE = 'openid';
+  process.env.SHOW_SURVEY = 'true';
+
 
   process.env.MTLS_PRIVATE_KEY_ARN = 'testarn';
 
@@ -110,7 +112,7 @@ describe('Loading the uitkeringspagina', () => {
     if (!result.body) {
       return;
     }
-    fs.writeFile(path.join(__dirname, 'output', 'test.html'), result.body, () => {});
+    fs.writeFile(path.join(__dirname, 'output', 'test.html'), result.body.replaceAll('href="/static', 'href="../../../static-resources/static'), () => {});
   });
 
   test('Companies are redirected', async () => {

--- a/src/app/uitkeringen/uitkeringsRequestHandler.ts
+++ b/src/app/uitkeringen/uitkeringsRequestHandler.ts
@@ -8,6 +8,7 @@ import * as uitkering from './templates/uitkerings-item.mustache';
 import { UitkeringsApi } from './UitkeringsApi';
 import { Navigation } from '../../shared/Navigation';
 import { render } from '../../shared/render';
+import * as surveyCTA from '../../shared/survey-cta.mustache';
 
 interface Config {
   apiClient: ApiClient;
@@ -66,7 +67,10 @@ export class uitkeringsRequestHandler {
     data.shownav = true;
 
     // render page
-    const html = await render(data, template.default, { uitkering: uitkering.default });
+    const html = await render(data, template.default, {
+      uitkering: uitkering.default,
+      surveyCTA: process.env.SHOW_SURVEY == 'true' ? surveyCTA.default : undefined,
+    });
     return html;
   }
 }

--- a/src/app/zaken/templates/zaak.mustache
+++ b/src/app/zaken/templates/zaak.mustache
@@ -196,10 +196,11 @@
                 <h1>Geen zaak gevonden</h1>
                 <p>We konden geen zaak vinden met dit kenmerk.</p>
             {{/zaak}}
+
+            {{ >surveyCTA }}
             </div>
         </div>
     </div>
-
     <!-- END: template component(s) -->
 </main>
 {{>footer}}

--- a/src/app/zaken/tests/requestHandler.test.ts
+++ b/src/app/zaken/tests/requestHandler.test.ts
@@ -169,7 +169,7 @@ describe('Request handler class', () => {
     expect(result.statusCode).toBe(200);
     if (result.body) {
       try {
-        writeFile(path.join(__dirname, 'output', 'test.html'), result.body, () => { });
+        writeFile(path.join(__dirname, 'output', 'test.html'), result.body.replaceAll('href="/static', 'href="../../../static-resources/static'), () => { });
       } catch (error) {
         console.debug(error);
       }

--- a/src/app/zaken/zakenRequestHandler.ts
+++ b/src/app/zaken/zakenRequestHandler.ts
@@ -8,6 +8,7 @@ import { ZaakAggregator } from './ZaakAggregator';
 import { ZaakFormatter } from './ZaakFormatter';
 import { Navigation } from '../../shared/Navigation';
 import { render } from '../../shared/render';
+import * as surveyCTA from '../../shared/survey-cta.mustache';
 
 export class ZakenRequestHandler {
   private zaakAggregator: ZaakAggregator;
@@ -73,7 +74,9 @@ export class ZakenRequestHandler {
         zaak: formattedZaak,
       };
       // render page
-      const html = await render(data, zaakTemplate.default);
+      const html = await render(data, zaakTemplate.default, {
+        surveyCTA: process.env.SHOW_SURVEY == 'true' ? surveyCTA.default : undefined,
+      });
       return Response.html(html, 200, session.getCookie());
     } else {
       return Response.error(404);

--- a/src/shared/survey-cta.mustache
+++ b/src/shared/survey-cta.mustache
@@ -1,0 +1,6 @@
+<div class="alert alert-info cta">
+  We zijn benieuwd naar uw ervaringen met Mijn Nijmegen. Mogen we u in een korte enquete (5 minuten) hier wat over vragen?
+  <a href="https://nijmegen.nl" class="btn btn-secondary">
+      Geef uw mening
+  </a>
+</div>

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -8,7 +8,7 @@
     "inlineSourceMap": true,
     "inlineSources": true,
     "lib": [
-      "es2019"
+      "es2021"
     ],
     "module": "CommonJS",
     "noEmitOnError": false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "inlineSourceMap": true,
     "inlineSources": true,
     "lib": [
-      "es2019"
+      "es2021"
     ],
     "module": "CommonJS",
     "noEmitOnError": false,


### PR DESCRIPTION
Adds an (optional) survey call-to-action to pages on Mijn Nijmegen. For now it's governed by feature flag, and alway shows on the selected pages. the URL is hardcoded (to nijmegen.nl) for now.

required for #1081
