### PR TITLE
chore: speed up pipeline by caching node modules in runner instance

### DIFF
--- a/src/PipelineStack.ts
+++ b/src/PipelineStack.ts
@@ -1,7 +1,7 @@
 import { PermissionsBoundaryAspect } from '@gemeentenijmegen/aws-constructs';
 import { getNodeVersion } from '@gemeentenijmegen/projen-project-type';
 import { Aspects, CfnParameter, Stack, StackProps, Tags, pipelines } from 'aws-cdk-lib';
-import { BuildSpec } from 'aws-cdk-lib/aws-codebuild';
+import { BuildSpec, Cache, LocalCacheMode } from 'aws-cdk-lib/aws-codebuild';
 import { PipelineType } from 'aws-cdk-lib/aws-codepipeline';
 import { Construct } from 'constructs';
 import { ApiStage } from './ApiStage';
@@ -64,6 +64,7 @@ export class PipelineStack extends Stack {
       synth: synthStep,
       pipelineType: PipelineType.V1,
       synthCodeBuildDefaults: {
+        cache: Cache.local(LocalCacheMode.CUSTOM),
         partialBuildSpec: BuildSpec.fromObject({
           phases: {
             install: {
@@ -71,6 +72,9 @@ export class PipelineStack extends Stack {
                 nodejs: getNodeVersion(),
               },
             },
+          },
+          cache: {
+            paths: ['node_modules'],
           },
         }),
       },

--- a/src/app/producten/Arc.ts
+++ b/src/app/producten/Arc.ts
@@ -15,12 +15,12 @@ export class Arc {
     try {
       const json = await result.json() as any;
       if (!json.url || typeof json.url !== 'string') {
-        throw new Error(`ARC did not return a valid url.`);
+        throw new Error('ARC did not return a valid url.');
       }
       return json.url;
     } catch (err: any) {
       console.error('unexpected response from arc,', err);
-      throw Error("Could not get redirect url from ARC");
+      throw Error('Could not get redirect url from ARC');
     }
   }
 

--- a/src/app/producten/WalletRequestHandler.ts
+++ b/src/app/producten/WalletRequestHandler.ts
@@ -2,10 +2,10 @@ import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { Response } from '@gemeentenijmegen/apigateway-http/lib/V2/Response';
 import { Session } from '@gemeentenijmegen/session';
 import { environmentVariables } from '@gemeentenijmegen/utils';
-import { Navigation } from '../../shared/Navigation';
-import { render } from '../../shared/render';
 import { Arc } from './Arc';
 import * as walletTemplate from './templates/wallet.mustache';
+import { Navigation } from '../../shared/Navigation';
+import { render } from '../../shared/render';
 
 interface walletEventRequestParams {
   cookies: string;


### PR DESCRIPTION
If the cache is triggered it could save about +-45s:
```
yarn install v1.22.22
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
warning " > @aws-solutions-constructs/aws-lambda-dynamodb@2.100.1" has unmet peer dependency "@aws-solutions-constructs/core@2.100.1".
warning " > @gemeentenijmegen/projen-project-type@1.12.2" has incorrect peer dependency "projen@0.99.9".
warning "aws-cdk-lib > @aws-cdk/cloud-assembly-api@2.2.0" has incorrect peer dependency "@aws-cdk/cloud-assembly-schema@>=53.0.0".
[4/4] Building fresh packages...
Done in 47.80s.
```
This is low hanging fruit for field labs, tested in arc-fra. See https://github.com/GemeenteNijmegen/devops/issues/1229 for an organization wide pipeline optimization