### PR TITLE
fix: no mail records to prod

### DIFF
--- a/src/DNSStack.ts
+++ b/src/DNSStack.ts
@@ -35,6 +35,7 @@ export class DNSStack extends Stack {
     this.addNSToRootCSPzone();
     this.addDsRecord(props.configuration.dsRecord);
     this.addCnameRecords(props.configuration.cnameRecords);
+    this.addNoMailRecords();
 
   }
 
@@ -116,6 +117,30 @@ export class DNSStack extends Stack {
         domainName: record[1],
         zone: this.zone,
       });
+    });
+  }
+  /**
+   * Creates records
+   * TXT with sender policy framework no mailserver allowed
+   * MX 0 . receives no mail
+   * Recommended by internet.nl
+   * Test on internet.nl e-mailsettings
+   */
+  private addNoMailRecords() {
+
+    new Route53.TxtRecord(this, 'no-mail-spf-record', {
+      zone: this.zone,
+      values: ['v=spf1 -all'],
+    });
+
+    new Route53.MxRecord(this, 'null-mx-record', {
+      zone: this.zone,
+      values: [
+        {
+          priority: 0,
+          hostName: '.',
+        },
+      ],
     });
   }
 }


### PR DESCRIPTION
Ivm NLDS wijzigingen daarna terugmergen naar acc en dev.

https://github.com/GemeenteNijmegen/devops/issues/1518

Eerste test of deze no mail records het probleem oplossen van de falende e-mailsettings internet.nl test is op acceptatie geslaagd zonder impact. 

Advies van internet.nl gevolgd:
```
B. Single no-mail domain with A or AAAA record

example.org. AAAA 2a00:d78:0:712:94:198:159:35
example.org. A 94.198.159.35
example.org. MX 0 .
example.org. TXT "v=spf1 -all"
*.example.org. TXT "v=spf1 -all"
www.example.org. CNAME example.nl
_dmarc.example.org. TXT "v=DMARC1; p=reject"

```
**example.org. MX 0 .
example.org. TXT "v=spf1 -all"
*.example.org. TXT "v=spf1 -all"**


Omdat het een Cname naar onze route 53 is, zouden deze records opgepakt moeten worden aan onze kant. De DMARC settings staan wel goed en aan de kant van de domain hosting.